### PR TITLE
[refactor] Unify custom_op namespace and remove deprecated code in flash_attn_interface

### DIFF
--- a/flash_attn_npu/flash_attn_interface.py
+++ b/flash_attn_npu/flash_attn_interface.py
@@ -16,32 +16,6 @@ def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
-def _get_block_size_n(device, head_dim, is_dropout, is_causal):
-    # This should match the block sizes in the CUDA kernel
-    assert head_dim <= 256
-    major, minor = torch.cuda.get_device_capability(device)
-    is_sm8x = major == 8 and minor > 0  # Only include sm86 and sm89, exclude sm80 (A100)
-    is_sm80 = major == 8 and minor == 0
-    is_sm90 = major == 9 and minor == 0
-    if head_dim <= 32:
-        return 128
-    if head_dim <= 64:
-        return 128 if not is_dropout else 64
-    elif head_dim <= 96:
-        return 64
-    elif head_dim <= 128:
-        if is_sm8x:
-            return 64 if (not is_dropout and is_causal) else 32
-        else:
-            return 64 if not is_dropout else 32
-    elif head_dim <= 192:
-        return 64
-    elif head_dim <= 224:
-        return 64
-    elif head_dim <= 256:
-        return 64
-
-
 def round_multiple(x, m):
     return (x + m - 1) // m * m
 
@@ -69,7 +43,7 @@ else:
     _torch_register_fake_wrapper = noop_register_fake_wrapper
 
 
-@_torch_custom_op_wrapper("flash_attn_npu::_flash_attn_forward", mutates_args=(), device_types="npu")
+@_torch_custom_op_wrapper("flash_attn_npu_2::_flash_attn_forward", mutates_args=(), device_types="npu")
 def _flash_attn_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -102,7 +76,7 @@ def _flash_attn_forward(
     return out, softmax_lse, S_dmask, rng_state
 
 
-@_torch_register_fake_wrapper("flash_attn_npu::_flash_attn_forward")
+@_torch_register_fake_wrapper("flash_attn_npu_2::_flash_attn_forward")
 def _flash_attn_forward_fake(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -135,7 +109,7 @@ def _flash_attn_forward_fake(
 _wrapped_flash_attn_forward = _flash_attn_forward
 
 
-@_torch_custom_op_wrapper("flash_attn_npu::_flash_attn_varlen_forward", mutates_args=(), device_types="npu")
+@_torch_custom_op_wrapper("flash_attn_npu_2::_flash_attn_varlen_forward", mutates_args=(), device_types="npu")
 def _flash_attn_varlen_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -186,7 +160,7 @@ def _flash_attn_varlen_forward(
     return out, softmax_lse, S_dmask, rng_state
 
 
-@_torch_register_fake_wrapper("flash_attn_npu::_flash_attn_varlen_forward")
+@_torch_register_fake_wrapper("flash_attn_npu_2::_flash_attn_varlen_forward")
 def _flash_attn_varlen_forward_fake(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -227,7 +201,7 @@ def _flash_attn_varlen_forward_fake(
 _wrapped_flash_attn_varlen_forward = _flash_attn_varlen_forward
 
 
-@_torch_custom_op_wrapper("flash_attn_npu::_flash_attn_backward", mutates_args=("dq", "dk", "dv"), device_types="npu")
+@_torch_custom_op_wrapper("flash_attn_npu_2::_flash_attn_backward", mutates_args=("dq", "dk", "dv"), device_types="npu")
 def _flash_attn_backward(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -279,7 +253,7 @@ def _flash_attn_backward(
     return softmax_d
 
 
-@_torch_register_fake_wrapper("flash_attn_npu::_flash_attn_backward")
+@_torch_register_fake_wrapper("flash_attn_npu_2::_flash_attn_backward")
 def _flash_attn_backward_fake(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -319,7 +293,7 @@ def _flash_attn_backward_fake(
 _wrapped_flash_attn_backward = _flash_attn_backward
 
 
-@_torch_custom_op_wrapper("flash_attn_npu::_flash_attn_varlen_backward", mutates_args=("dq", "dk", "dv"), device_types="npu")
+@_torch_custom_op_wrapper("flash_attn_npu_2::_flash_attn_varlen_backward", mutates_args=("dq", "dk", "dv"), device_types="npu")
 def _flash_attn_varlen_backward(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -383,7 +357,7 @@ def _flash_attn_varlen_backward(
     return softmax_d
 
 
-@_torch_register_fake_wrapper("flash_attn_npu::_flash_attn_varlen_backward")
+@_torch_register_fake_wrapper("flash_attn_npu_2::_flash_attn_varlen_backward")
 def _flash_attn_varlen_backward_fake(
     dout: torch.Tensor,
     q: torch.Tensor,

--- a/flash_attn_npu_v3/flash_attn_interface.py
+++ b/flash_attn_npu_v3/flash_attn_interface.py
@@ -60,7 +60,7 @@ def round_up_headdim(head_size: int) -> int:
     return 256
 
 
-@_torch_custom_op_wrapper("flash_attn_3_C::_flash_attn_forward", mutates_args=(), device_types="npu")
+@_torch_custom_op_wrapper("flash_attn_npu_3::_flash_attn_forward", mutates_args=(), device_types="npu")
 def _flash_attn_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -154,7 +154,7 @@ def _flash_attn_forward(
     return out, softmax_lse, out_accum, softmax_lse_accum
 
 
-@_torch_register_fake_wrapper("flash_attn_3_C::_flash_attn_forward")
+@_torch_register_fake_wrapper("flash_attn_npu_3::_flash_attn_forward")
 def _flash_attn_forward_fake(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -259,7 +259,7 @@ def _flash_attn_forward_fake(
     return out, softmax_lse, out_accum, softmax_lse_accum
 
 
-@_torch_custom_op_wrapper("flash_attn_3_C::_flash_attn_backward", mutates_args=("dq", "dk", "dv"), device_types="cuda")
+@_torch_custom_op_wrapper("flash_attn_npu_3::_flash_attn_backward", mutates_args=("dq", "dk", "dv"), device_types="npu")
 def _flash_attn_backward(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -313,7 +313,7 @@ def _flash_attn_backward(
     return softmax_d
 
 
-@_torch_register_fake_wrapper("flash_attn_3_C::_flash_attn_backward")
+@_torch_register_fake_wrapper("flash_attn_npu_3::_flash_attn_backward")
 def _flash_attn_backward_fake(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -369,30 +369,9 @@ def _flash_attn_backward_fake(
     head_size_v = v.size(-1)
     head_size_rounded = round_up_headdim(max(head_size, head_size_v))
 
-    # Hopper gpus uses cuda compute capabilities 9.0
-    cap = torch.cuda.get_device_capability(q.device)
-    arch = cap[0] * 10 + cap[1]
-
     is_local = (window_size_left >= 0 or window_size_right >= 0) and not is_causal
 
-    if head_size_rounded <= 64:
-        kBlockM_sm90 = 96 if (is_causal and softcap > 0.0) else 128
-    elif head_size_rounded <= 96:
-        kBlockM_sm90 = 64
-    elif head_size_rounded <= 128:
-        kBlockM_sm90 = 64 if (is_causal or is_local or softcap > 0.0) else 80
-    else:
-        kBlockM_sm90 = 64
-
-    kBlockM_sm80 = 128 if head_size_rounded <= 64 else 64
-    kBlockM_sm86 = 64 if head_size_rounded <= 192 else 32
-
-    if arch >= 90:
-        kBlockM = kBlockM_sm90
-    elif arch == 86 or arch == 89:
-        kBlockM = kBlockM_sm86
-    else:
-        kBlockM = kBlockM_sm80
+    kBlockM = 128
 
     num_heads = q.shape[-2]
     seqlen_q_rounded = round_multiple(seqlen_q, kBlockM)


### PR DESCRIPTION

## ️Related Issue
<!-- If this PR solves any issue, describe it below:
> **Example:** `fixes #1111`, `closes #1234` -->
Resolves #9 

## Description
<!-- 
  Please provide a detailed summary of the changes.
  Fixed? Feat?
- What is the motivation behind this PR?
- Why is this change necessary?
-->
- Rename v2 namespace "flash_attn_npu::" to "flash_attn_npu_2::", and rename v3 namespace "flash_attn_3_C::" to "flash_attn_npu_3::"
- Remove legacy CUDA-specific code paths and adapt relative logic for NPU

## Changes
<!-- List the key changes made in this PR -->
- [x] Changed ...
- [x] Added ...
- [x] Removed ...

## Additional Information
<!-- Testing, Benchmark, etc. -->
None