### PR TITLE
FD support num_splits

### DIFF
--- a/csrc/flash_attn_npu_v3/flash_api.cpp
+++ b/csrc/flash_attn_npu_v3/flash_api.cpp
@@ -62,6 +62,7 @@ struct SplitContext {
     int32_t* seqlens_k_cpu;
     bool is_varlen_q;
     uint32_t blockDim;
+    int32_t num_splits;
 };
 
 BatchParams getBatchParams(uint32_t bIdx, uint32_t groupSize, const SplitContext& ctx) {
@@ -327,11 +328,159 @@ void fillSplitInfoForFlashDecode(FAInferTilingData* tiling, uint32_t groupSize,
     tiling->set_splitLseTotalSize(currentLseTaskOffset * SIZE_OF_32BIT);
     tiling->set_splitOTotalSize(currentOTaskOffset * SIZE_OF_32BIT);
 }
+uint32_t countForceSplitSegments(uint32_t groupSize, const SplitContext& ctx) {
+    uint32_t totalSegs = 0;
+    uint32_t nsplit = static_cast<uint32_t>(ctx.num_splits);
+    for (int32_t b = 0; b < ctx.batch_size; b++) {
+        BatchParams p = getBatchParams(b, groupSize, ctx);
+        uint32_t curKSBlockNum = p.curKSBlockNum;
+        if (curKSBlockNum == 0) { continue; }
+        uint32_t blocksPerSplit = (curKSBlockNum + nsplit - 1) / nsplit;
+        if (blocksPerSplit == 0) { blocksPerSplit = 1; }
+        uint32_t actualSplits = (curKSBlockNum + blocksPerSplit - 1) / blocksPerSplit;
+        totalSegs += p.curQNBlockNum * p.curQSBlockNum * actualSplits;
+    }
+    return totalSegs;
+}
+
+void fillCoreInfoForceSplit(FAInferTilingData* tiling, uint32_t groupSize,
+                            const SplitContext& ctx) {
+    for (uint32_t coreIdx = 0; coreIdx < ctx.blockDim; coreIdx++) {
+        tiling->coreInfo[coreIdx].startBIdx = 0;
+        tiling->coreInfo[coreIdx].startN1Idx = 0;
+        tiling->coreInfo[coreIdx].startS1Idx = 0;
+        tiling->coreInfo[coreIdx].startS2Idx = 0;
+        tiling->coreInfo[coreIdx].endBIdx = 0;
+        tiling->coreInfo[coreIdx].endN1Idx = 0;
+        tiling->coreInfo[coreIdx].endS1Idx = 0;
+        tiling->coreInfo[coreIdx].endS2Idx = 0;
+    }
+
+    uint32_t nsplit = static_cast<uint32_t>(ctx.num_splits);
+    uint32_t coreIdx = 0;
+    for (int32_t b = 0; b < ctx.batch_size; b++) {
+        BatchParams p = getBatchParams(b, groupSize, ctx);
+        uint32_t curKSBlockNum = p.curKSBlockNum;
+        if (curKSBlockNum == 0) { continue; }
+        uint32_t blocksPerSplit = (curKSBlockNum + nsplit - 1) / nsplit;
+        if (blocksPerSplit == 0) { blocksPerSplit = 1; }
+        for (uint32_t n1 = 0; n1 < p.curQNBlockNum; n1++) {
+            for (uint32_t s1 = 0; s1 < p.curQSBlockNum; s1++) {
+                for (uint32_t segStart = 0; segStart < curKSBlockNum; segStart += blocksPerSplit) {
+                    uint32_t segEnd = std::min(segStart + blocksPerSplit, curKSBlockNum);
+                    if (coreIdx >= ctx.blockDim) { break; }
+                    tiling->coreInfo[coreIdx].startBIdx = b;
+                    tiling->coreInfo[coreIdx].endBIdx = b;
+                    tiling->coreInfo[coreIdx].startN1Idx = static_cast<int>(n1);
+                    tiling->coreInfo[coreIdx].endN1Idx = static_cast<int>(n1);
+                    tiling->coreInfo[coreIdx].startS1Idx = static_cast<int>(s1);
+                    tiling->coreInfo[coreIdx].endS1Idx = static_cast<int>(s1);
+                    tiling->coreInfo[coreIdx].startS2Idx = static_cast<int>(segStart);
+                    tiling->coreInfo[coreIdx].endS2Idx = static_cast<int>(segEnd);
+                    coreIdx++;
+                }
+            }
+        }
+    }
+    tiling->set_needCoreNum(coreIdx);
+}
+
+void fillCoreInfoNoSplit(FAInferTilingData* tiling, uint32_t groupSize,
+                         const SplitContext& ctx) {
+    for (uint32_t coreIdx = 0; coreIdx < ctx.blockDim; coreIdx++) {
+        tiling->coreInfo[coreIdx].startBIdx = 0;
+        tiling->coreInfo[coreIdx].startN1Idx = 0;
+        tiling->coreInfo[coreIdx].startS1Idx = 0;
+        tiling->coreInfo[coreIdx].startS2Idx = 0;
+        tiling->coreInfo[coreIdx].endBIdx = 0;
+        tiling->coreInfo[coreIdx].endN1Idx = 0;
+        tiling->coreInfo[coreIdx].endS1Idx = 0;
+        tiling->coreInfo[coreIdx].endS2Idx = 0;
+    }
+
+    uint32_t totalTasks = 0;
+    for (int32_t b = 0; b < ctx.batch_size; b++) {
+        BatchParams p = getBatchParams(b, groupSize, ctx);
+        totalTasks += p.curQNBlockNum * p.curQSBlockNum;
+    }
+    if (totalTasks == 0) { tiling->set_needCoreNum(0); return; }
+
+    uint32_t tasksPerCore = (totalTasks + ctx.blockDim - 1) / ctx.blockDim;
+
+    auto locate = [&](uint32_t gidx, int32_t& B, int32_t& N1, int32_t& S1, uint32_t& ksBlk) {
+        uint32_t acc = 0;
+        for (int32_t b = 0; b < ctx.batch_size; b++) {
+            BatchParams p = getBatchParams(b, groupSize, ctx);
+            uint32_t cnt = p.curQNBlockNum * p.curQSBlockNum;
+            if (cnt == 0) { continue; }
+            if (gidx < acc + cnt) {
+                uint32_t local = gidx - acc;
+                B = b;
+                N1 = static_cast<int32_t>(local / p.curQSBlockNum);
+                S1 = static_cast<int32_t>(local % p.curQSBlockNum);
+                ksBlk = p.curKSBlockNum;
+                return;
+            }
+            acc += cnt;
+        }
+        B = ctx.batch_size - 1;
+        BatchParams p = getBatchParams(B, groupSize, ctx);
+        N1 = static_cast<int32_t>(p.curQNBlockNum) - 1;
+        S1 = static_cast<int32_t>(p.curQSBlockNum) - 1;
+        ksBlk = p.curKSBlockNum;
+    };
+
+    uint32_t usedCores = 0;
+    for (uint32_t coreIdx = 0; coreIdx < ctx.blockDim; coreIdx++) {
+        uint32_t taskLo = coreIdx * tasksPerCore;
+        if (taskLo >= totalTasks) { break; }
+        uint32_t taskHi = std::min(taskLo + tasksPerCore, totalTasks);
+
+        int32_t b0, n0, s0; uint32_t ks0;
+        int32_t b1, n1, s1; uint32_t ks1;
+        locate(taskLo, b0, n0, s0, ks0);
+        locate(taskHi - 1, b1, n1, s1, ks1);
+
+        tiling->coreInfo[coreIdx].startBIdx = b0;
+        tiling->coreInfo[coreIdx].startN1Idx = n0;
+        tiling->coreInfo[coreIdx].startS1Idx = s0;
+        tiling->coreInfo[coreIdx].startS2Idx = 0;                         // whole-KV start
+        tiling->coreInfo[coreIdx].endBIdx = b1;
+        tiling->coreInfo[coreIdx].endN1Idx = n1;
+        tiling->coreInfo[coreIdx].endS1Idx = s1;
+        tiling->coreInfo[coreIdx].endS2Idx = static_cast<int32_t>(ks1);   // whole-KV end -> no split
+        usedCores = coreIdx + 1;
+    }
+    tiling->set_needCoreNum(usedCores);
+}
 
 void splitBN2S1GS2(FAInferTilingData* tiling, const SplitContext& ctx) {
     uint64_t totalTaskNum = 0;
     uint32_t groupSize = ctx.num_heads / ctx.num_heads_k;
 
+    //   num_splits==1 -> each task is one whole-KV segment (no split, see below).
+    //   num_splits>1  -> each task's KV is actively split into num_splits segments.
+    if (ctx.num_splits >= 1) {
+        uint32_t totalSegs = countForceSplitSegments(groupSize, ctx);
+        uint32_t coreCap = std::min(ctx.blockDim, static_cast<uint32_t>(25));
+        if (totalSegs > 0 && totalSegs <= coreCap) {
+            // Fits one-segment-per-core. For num_splits==1, blocksPerSplit==curKSBlockNum,
+            // so each task is a single whole-KV segment -> isSplitKV=false -> not split.
+            fillCoreInfoForceSplit(tiling, groupSize, ctx);
+            fillSplitInfoForFlashDecode(tiling, groupSize, ctx);
+            return;
+        }
+        if (ctx.num_splits == 1) {
+            // Tasks exceed cores: a core must serially handle multiple tasks. Use the
+            // whole-task layout so NO task's KV is ever split (the guarantee num_splits==1
+            // must hold even when #tasks > #cores).
+            fillCoreInfoNoSplit(tiling, groupSize, ctx);
+            fillSplitInfoForFlashDecode(tiling, groupSize, ctx);
+            return;
+        }
+    }
+
+    // num_splits==0 (auto), or num_splits>1 overflow: default core-balanced split.
     for (int32_t batchIdx = 0; batchIdx < ctx.batch_size; batchIdx++) {
         BatchParams p = getBatchParams(batchIdx, groupSize, ctx);
         totalTaskNum += static_cast<uint64_t>(ctx.num_heads) * p.qSeqlen * p.kvSeqlen;
@@ -447,7 +596,9 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     TORCH_CHECK(window_size_right == -1, "NPU FlashAttention does not support window_size_right");
     TORCH_CHECK(attention_chunk == 0, "NPU FlashAttention does not support attention_chunk");
     TORCH_CHECK(!scheduler_metadata_.has_value(), "NPU FlashAttention does not support scheduler_metadata");
-    TORCH_CHECK(num_splits == 1 || num_splits == 0, "NPU FlashAttention only supports num_splits=1 or num_splits=0");
+    TORCH_CHECK(num_splits >= 0 && num_splits <= static_cast<int64_t>(blockDim),
+                "NPU FlashAttention supports num_splits in [0, ", blockDim,
+                "] (0 = auto; upper bound = number of AI cores). ");
     TORCH_CHECK(!pack_gqa_.has_value() || !pack_gqa_.value(), "NPU FlashAttention does not support pack_gqa");
 
     if (is_varlen_kv) {
@@ -574,6 +725,8 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         (maxKVSeqlenCalc >= static_cast<int64_t>(blockDim) * 512);
     bool isShortSeq = (static_cast<double>(numTasks) <= 0.4 * blockDim) &&
         (maxKVSeqlenCalc >= 1024);
+    TORCH_CHECK(num_splits <= 1 || (paged_KV && is_varlen_q),
+                "NPU FlashAttention num_splits>1 currently requires paged KV cache and varlen-q (TND) layout");
     bool flashDecodeFlag = paged_KV && is_varlen_q &&
         (maxQSeqlenCalc * groupSize <= 128) && (maxQSeqlenCalc <= 16) &&
         (maxKVSeqlenCalc >= 1024) && (minQSeqlenCalc > 0) && (isLongSeq || isShortSeq);
@@ -588,6 +741,8 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     splitCtx.seqlens_k_cpu = seqlens_k_cpu;
     splitCtx.is_varlen_q = is_varlen_q;
     splitCtx.blockDim = blockDim;
+    splitCtx.num_splits = static_cast<int32_t>(num_splits);
+    tiling_cpu_ptr->set_numSplits(num_splits > 0 ? static_cast<uint32_t>(num_splits) : 1U);
     if (flashDecodeFlag) {
         splitBN2S1GS2(tiling_cpu_ptr, splitCtx);
         auto needCoreNum = tiling_cpu_ptr->get_needCoreNum();

--- a/csrc/flash_attn_npu_v3/tilingdata.h
+++ b/csrc/flash_attn_npu_v3/tilingdata.h
@@ -58,6 +58,7 @@ struct FAInferTilingData {
     uint64_t splitOTotalSize;
     uint32_t totalSplitNodeNum;
     uint32_t needCoreNum;
+    uint32_t numSplits;
     coreNode coreInfo[25];
     splitNode splitInfo[25];
 
@@ -87,6 +88,7 @@ struct FAInferTilingData {
     uint64_t get_splitOTotalSize() const { return splitOTotalSize; }
     uint32_t get_totalSplitNodeNum() const { return totalSplitNodeNum; }
     uint32_t get_needCoreNum() const { return needCoreNum; }
+    uint32_t get_numSplits() const { return numSplits; }
 
     void set_numHeads(uint32_t value) { numHeads = value; }
     void set_embeddingSize(uint32_t value) { embeddingSize = value; }
@@ -114,6 +116,7 @@ struct FAInferTilingData {
     void set_splitOTotalSize(uint64_t value) { splitOTotalSize = value; }
     void set_totalSplitNodeNum(uint32_t value) { totalSplitNodeNum = value; }
     void set_needCoreNum(uint32_t value) { needCoreNum = value; }
+    void set_numSplits(uint32_t value) { numSplits = value; }
 };
 
 #endif

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -140,7 +140,7 @@ def ref_flash_attention(
     return go.to(data_type), lse
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal)
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout)
     (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "TND"),
     (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "TND"),
     (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, "TND"),
@@ -153,10 +153,17 @@ test_cases = [
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "TND"),
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "BSND"),
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "BSND"),
+    # kv=4096 -> 8 S2 blocks: num_splits=2 -> 2 segs (4 blk each), num_splits=4 -> 4 segs (2 blk each).
+    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND"),
+    (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, "TND"),
 ]
 
+@pytest.mark.parametrize("num_splits", [0, 1, 2])
 @pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout", test_cases)
-def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout):
+def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, num_splits):
+    # num_splits>1 (active KV split) is currently only wired for paged KV + varlen-q (TND).
+    if num_splits > 1 and not (cache_mode == 1 and layout == "TND"):
+        pytest.skip("num_splits>1 requires paged KV cache and TND (varlen-q) layout")
     q_min_range = -1.0
     q_max_range = 1.0
     kv_min_range = -1.0
@@ -206,7 +213,6 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     window_size_right = -1
     is_rotary_interleaved = False
     softcap = 0
-    num_splits = 0
     kv_seqlen_list = torch.tensor(kv_seqlen_list, dtype=torch.int32).npu()
     rotary_cos = None
     rotary_sin = None


### PR DESCRIPTION
## ️Related Issue
<!-- If this PR solves any issue, describe it below:
> **Example:** `fixes #1111`, `closes #1234` -->
None.

## Description
添加 flashdecoding 使能num_splits的功能

num_splits=0（auto）：走原被动均分逻辑
num_splits=1：绝对不切分 KV — 任务数 ≤ 核数时每任务一核走整段 KV；任务数 > 核数时走 fillCoreInfoNoSplit，一核串行多任务但每个任务的 KV 保持完整
num_splits>1 且总段数 ≤ 核数：每个任务的 KV 强制均分 num_splits 段，每段映射一个核，下游 fillSplitInfoForFlashDecode 自动将其聚合为 splitNode，kernel 端和 CombineScale 合并链路零改动复用
num_splits>1 且总段数 > 核数：hint 被忽略，回退被动均分


## Changes
<!-- List the key changes made in this PR -->
- [ ] Changed ...
- [ ] Added ...
- [ ] Removed ...

## Additional Information
<!-- Testing, Benchmark, etc. -->
None