### PR TITLE
flash-attention-npu backward support  the shape of softmax_lse as NT/BNS

### DIFF
--- a/csrc/flash_attn_npu/fag_epilogue_op.hpp
+++ b/csrc/flash_attn_npu/fag_epilogue_op.hpp
@@ -121,6 +121,7 @@ public:
     int64_t dAlign;
     int64_t value_dAlign;
     int64_t attenMaskDimS2;
+    int64_t t1;
 
     uint32_t baseMN;
     uint32_t cubeBaseMN;
@@ -260,6 +261,7 @@ public:
         s2 = tilingData->kvSeqlen;
         d = tilingData->qkHeadDim;
         value_d = tilingData->vHeadDim;
+        t1 = tilingData->t1;
         dAlign = (d + 15) / 16 * 16;
         value_dAlign = (value_d + 15) / 16 * 16;
 
@@ -529,31 +531,13 @@ public:
     CATLASS_DEVICE
     void CopyInSoftMax(LocalTensor<float> &dstTensor, uint32_t s1Extend, uint32_t softMaxOffset)
     {
-        if constexpr (INPUT_LAYOUT == TND) {
-            AscendC::DataCopyPad(dstTensor, softmaxLseGm[softMaxOffset],
-                {1, static_cast<uint16_t>(s1Extend * 4), 0, 0}, {false, 0, 0, 0});
-        } else { // BSN
-            int64_t nheads = n2 * g;
-            int64_t lseRepeatTimes = (s1Extend + 7) / 8 * 8;
-            AscendC::DataCopyExtParams lseCopyParam;
-            lseCopyParam.blockCount = s1Extend;
-            lseCopyParam.blockLen = sizeof(float);
-            lseCopyParam.srcStride = (nheads - 1) * sizeof(float);
-            lseCopyParam.dstStride = 0;
-            lseCopyParam.rsv = 0;
-            AscendC::DataCopyPad(dstTensor, softmaxLseGm[softMaxOffset], lseCopyParam, {false, 0, 0, 0});
-        }
+        AscendC::DataCopyPad(dstTensor, softmaxLseGm[softMaxOffset],
+            {1, static_cast<uint16_t>(s1Extend * 4), 0, 0}, {false, 0, 0, 0});
 
         event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventId);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventId);
-        if constexpr (INPUT_LAYOUT == TND) {
-            AscendC::Brcb(dstTensor[s1Extend * 8], dstTensor, static_cast<uint8_t>((s1Extend+7)/8), {1, 8});
-        } else {
-            for (uint32_t i = 0; i < s1Extend; i++) { // bsn
-                AscendC::Brcb(dstTensor[s1Extend * 8 + i * 8], dstTensor[i * 8], 1, {1, 8});
-            }
-        }
+        AscendC::Brcb(dstTensor[s1Extend * 8], dstTensor, static_cast<uint8_t>((s1Extend + 7) / 8), {1, 8});
     }
 
     CATLASS_DEVICE
@@ -629,12 +613,11 @@ public:
         int64_t softMaxOffset = 0;
         if constexpr (INPUT_LAYOUT == TND) {
             if (dbParam.bIdx > 0) {
-                softMaxOffset = ((__gm__ int32_t *)actual_seq_qlen_addr)[dbParam.bIdx - 1] * n2 * g;
+                softMaxOffset = ((__gm__ int32_t *)actual_seq_qlen_addr)[dbParam.bIdx - 1];
             }
-            softMaxOffset += ((dbParam.n2Idx * g + dbParam.gIdx) * dbParam.actualS1Len +
-                            dbParam.s1oIdx * s1CvInner + curS1Idx * s1VecSize);
+            softMaxOffset += (dbParam.n2Idx * g + dbParam.gIdx) * t1 + dbParam.s1oIdx * s1CvInner + curS1Idx * s1VecSize;
         } else {
-            softMaxOffset = ((dbParam.bIdx * s1 + dbParam.s1oIdx * s1CvInner + curS1Idx * s1VecSize) * n2 + dbParam.n2Idx) * g + dbParam.gIdx; // bsn
+            softMaxOffset = ((dbParam.bIdx * n2 + dbParam.n2Idx) * g + dbParam.gIdx) * s1 + dbParam.s1oIdx * s1CvInner + curS1Idx * s1VecSize; // bns
         }
         CopyInSoftMax(vecInBuffer3, s1ExtendSubGraph, softMaxOffset);
 
@@ -1068,6 +1051,7 @@ public:
     int64_t headdim;
     int64_t seq_q;
     int64_t seq_k;
+    int64_t t1;
 
     float scaleValue;
 
@@ -1124,7 +1108,8 @@ public:
         nheads_k = tilingData->kvHeadNum;
         g = tilingData->g;
         headdim = tilingData->qkHeadDim;
-        seq_q = tilingData->t1 / b;
+        t1 = tilingData->t1;
+        seq_q = t1 / b;
         seq_k = tilingData->t2 / b;
 
         int64_t sfmgWorkSpaceOffset = tilingData->sfmgPreBeginAddr;
@@ -1230,20 +1215,12 @@ public:
     CATLASS_DEVICE
     void CopyInSoftMax(LocalTensor<float> &dstTensor, uint32_t s1Extend, uint32_t softMaxOffset)
     {
-        int64_t nheads = nheads_k * g;
-        AscendC::DataCopyExtParams lseCopyParam;
-        lseCopyParam.blockCount = s1Extend;
-        lseCopyParam.blockLen = sizeof(float);
-        lseCopyParam.srcStride = (nheads - 1) * sizeof(float);
-        lseCopyParam.dstStride = 0;
-        lseCopyParam.rsv = 0;
-        AscendC::DataCopyPad(dstTensor, rowLseGm[softMaxOffset], lseCopyParam, {false, 0, 0, 0});
+        AscendC::DataCopyPad(dstTensor, rowLseGm[softMaxOffset],
+            {1, static_cast<uint16_t>(s1Extend * 4), 0, 0}, {false, 0, 0, 0});
         event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventId);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventId);
-        for (uint32_t i = 0; i < s1Extend; i++) {
-            AscendC::Brcb(dstTensor[64 * 8 + i * 8], dstTensor[i * 8], 1, {1, 8});
-        }
+        AscendC::Brcb(dstTensor[64 * 8], dstTensor, static_cast<uint8_t>((s1Extend + 7) / 8), {1, 8});
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Duplicate(dstTensor, 1.0f, s1Extend * 8);
     }
@@ -1454,19 +1431,19 @@ public:
 
             // offset
             int64_t globalSeqStart = 0;
+            int64_t batchOffset = 0;
             if constexpr (getLayout() == InputLayout::TND) {
                 globalSeqStart = (blockInfo.batchIdx > 0)
                 ? ((__gm__ int32_t *)cu_seq_qlen_addr)[blockInfo.batchIdx - 1]
                 : 0;
+                batchOffset = t1;
             } else {
-                globalSeqStart = (blockInfo.batchIdx > 0)
-                ? seq_q
-                : 0;
+                globalSeqStart = blockInfo.batchIdx * nheads_k * g * seq_q;
+                batchOffset = seq_q;
             }
+            int64_t headIdx = (blockInfo.nheadsKIdx * g + blockInfo.gIdx) * batchOffset;
             int64_t seqOffsetInBlock = blockInfo.SeqQIdx * S1_CUBESIZE + curSeqQIdx * s1VecSize;
-            int64_t nheads = nheads_k * g;
-            int64_t headIdx = blockInfo.nheadsKIdx * g + blockInfo.gIdx;
-            lseOffset = (globalSeqStart + seqOffsetInBlock) * nheads + headIdx;
+            lseOffset = globalSeqStart + headIdx + seqOffsetInBlock;
 
             sfmgOffset = 0;
             if (blockInfo.batchIdx > 0) {

--- a/csrc/flash_attn_npu/fag_general_host.cpp
+++ b/csrc/flash_attn_npu/fag_general_host.cpp
@@ -150,28 +150,20 @@ std::vector<at::Tensor> launch_fag_general(
     }
 
     at::Tensor softmax_lse_kernel = softmax_lse;
-    if (!is_varlen_q) {
+        if (!is_varlen_q) {
         TORCH_CHECK(softmax_lse.dim() == 3, "launch_fag_general: softmax_lse for BSND must be a 3D tensor.");
-        if (softmax_lse.size(1) == nheads && softmax_lse.size(2) == max_seqlen_q) {
-            softmax_lse_kernel = softmax_lse.transpose(1, 2).contiguous();
-        } else {
-            TORCH_CHECK(softmax_lse.size(1) == max_seqlen_q && softmax_lse.size(2) == nheads,
-                        "launch_fag_general: softmax_lse must be BSN or BHS in BSND mode.");
-            if (!softmax_lse.is_contiguous()) {
-                softmax_lse_kernel = softmax_lse.contiguous();
-            }
+        TORCH_CHECK(softmax_lse.size(1) == nheads && softmax_lse.size(2) == max_seqlen_q,
+                    "launch_fag_general: softmax_lse must be BNS in BSND mode.");
+        if (!softmax_lse.is_contiguous()) {
+            softmax_lse_kernel = softmax_lse.contiguous();
         }
     } else {
         TORCH_CHECK(softmax_lse.dim() == 2, "launch_fag_general: softmax_lse for TND must be a 2D tensor.");
         const int64_t total_q = qsizes[0];
-        if (softmax_lse.size(0) == nheads && softmax_lse.size(1) == total_q) {
-            softmax_lse_kernel = softmax_lse.transpose(0, 1).contiguous();
-        } else {
-            TORCH_CHECK(softmax_lse.size(0) == total_q && softmax_lse.size(1) == nheads,
-                        "launch_fag_general: softmax_lse must be TN or NT in TND mode.");
-            if (!softmax_lse.is_contiguous()) {
-                softmax_lse_kernel = softmax_lse.contiguous();
-            }
+        TORCH_CHECK(softmax_lse.size(0) == nheads && softmax_lse.size(1) == total_q,
+                    "launch_fag_general: softmax_lse must be NT (nheads, total_q) in TND mode.");
+        if (!softmax_lse.is_contiguous()) {
+            softmax_lse_kernel = softmax_lse.contiguous();
         }
     }
     auto softMaxLseDevice = static_cast<uint8_t *>(const_cast<void *>(softmax_lse_kernel.storage().data()));

--- a/csrc/flash_attn_npu/flash_api.cpp
+++ b/csrc/flash_attn_npu/flash_api.cpp
@@ -1132,7 +1132,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     const bool local_is_causal = local_window_size_left < 0 && local_window_size_right == 0;
     const bool is_local = (local_window_size_left >= 0 || local_window_size_right >= 0) && !local_is_causal;
 
-    if (!seqlens_q.equal(seqlens_k) || is_local) {
+    if (!seqlens_q.equal(seqlens_k) || is_local || headdim != 128) { // varlen optimized kernel only supports headdim equal to 128
         float scale = softmax_scale > 0.f ? softmax_scale : (1.0f / sqrt(static_cast<float>(headdim)));
         return launch_fag_general(
             dout, q, k, v, out, softmax_lse, dq, dk, dv,
@@ -1170,6 +1170,15 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     at::Tensor seqlenq_gpu_tensor = seqlens_q.to(at::Device(at::kPrivateUse1));
     at::Tensor seqlenk_gpu_tensor = seqlens_k.to(at::Device(at::kPrivateUse1));
 
+    at::Tensor softmax_lse_kernel = softmax_lse;
+    TORCH_CHECK(softmax_lse.dim() == 2, "mha_varlen_bwd: softmax_lse for TND must be a 2D tensor.");
+    const int64_t total_q = qsizes[0];
+    TORCH_CHECK(softmax_lse.size(0) == nheads && softmax_lse.size(1) == total_q,
+                "mha_varlen_bwd: softmax_lse must be NT (nheads, total_q) in TND mode.");
+    if (!softmax_lse.is_contiguous()) {
+        softmax_lse_kernel = softmax_lse.contiguous();
+    }
+
     uint64_t fftsAddr{0};
     uint32_t fftsLen{0};
     rtError_t error = rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
@@ -1184,7 +1193,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     }
     auto cuSeqQlenDevice = static_cast<uint8_t *>(const_cast<void *>(seqlenq_gpu_tensor.storage().data()));
     auto cuSeqKvlenDevice = static_cast<uint8_t *>(const_cast<void *>(seqlenk_gpu_tensor.storage().data()));
-    auto softMaxLseDevice = static_cast<uint8_t *>(const_cast<void *>(softmax_lse.storage().data()));
+    auto softMaxLseDevice = static_cast<uint8_t *>(const_cast<void *>(softmax_lse_kernel.storage().data()));
 
     auto workspaceDevice = static_cast<uint8_t *>(const_cast<void *>(workspace_tensor.storage().data()));
     auto tilingDevice = static_cast<uint8_t *>(const_cast<void *>(tiling_gpu_tensor.storage().data()));

--- a/csrc/flash_attn_npu_v3/fag_tiling.cpp
+++ b/csrc/flash_attn_npu_v3/fag_tiling.cpp
@@ -22,35 +22,27 @@ float CalculateMaskRatio(FAGTilingData &fagTilingData)
     // calculate ratio of all mask
     float realS1 = 0;
     float realS2 = 0;
-    if (fagTilingData.maskType == static_cast<uint32_t>(MaskType::NO_MASK)) {
+    if (fagTilingData.maskType == static_cast<uint32_t>(MaskType::NO_MASK) ||
+        fagTilingData.maskType == static_cast<uint32_t>(MaskType::MASK_BAND)) {
         if (fagTilingData.s1Token >= 0 && fagTilingData.s2Token >= 0) {
-            realS1 = fagTilingData.s1Token >= fagTilingData.qkHeadDim ? static_cast<float>(fagTilingData.qkHeadDim) :
-                                                             static_cast<float>(fagTilingData.s1Token);
-            realS2 = fagTilingData.s2Token >= fagTilingData.vHeadDim ? static_cast<float>(fagTilingData.vHeadDim) :
-                                                             static_cast<float>(fagTilingData.s2Token);
-            return (realS1 + realS2) / static_cast<float>(fagTilingData.qkHeadDim + fagTilingData.vHeadDim);
+            realS1 = fagTilingData.s1Token >= fagTilingData.qSeqlen ? static_cast<float>(fagTilingData.qSeqlen) :
+                                                                static_cast<float>(fagTilingData.s1Token);
+            realS2 = fagTilingData.s2Token >= fagTilingData.kvSeqlen ? static_cast<float>(fagTilingData.kvSeqlen) :
+                                                                static_cast<float>(fagTilingData.s2Token);
+            return (realS1 + realS2) / static_cast<float>(fagTilingData.qSeqlen + fagTilingData.kvSeqlen);
         } else if (fagTilingData.s1Token < 0 && fagTilingData.s2Token >= 0) {
-            realS2 = fagTilingData.s2Token >= fagTilingData.vHeadDim ? fagTilingData.vHeadDim : fagTilingData.s2Token;
-            return (realS2 + fagTilingData.s1Token) / static_cast<float>(fagTilingData.vHeadDim);
+            realS2 = fagTilingData.s2Token >= fagTilingData.kvSeqlen ? fagTilingData.kvSeqlen : fagTilingData.s2Token;
+            return (realS2 + fagTilingData.s1Token) / static_cast<float>(fagTilingData.kvSeqlen);
         } else {
-            realS1 = fagTilingData.s1Token >= fagTilingData.qkHeadDim ? fagTilingData.qkHeadDim : fagTilingData.s1Token;
-            return (realS1 + fagTilingData.s2Token) / static_cast<float>(fagTilingData.qkHeadDim);
+            realS1 = fagTilingData.s1Token >= fagTilingData.qSeqlen ? fagTilingData.qSeqlen : fagTilingData.s1Token;
+            return (realS1 + fagTilingData.s2Token) / static_cast<float>(fagTilingData.qSeqlen);
         }
     } else if (fagTilingData.maskType == static_cast<uint32_t>(MaskType::MASK_CAUSUAL)) {
-        if (fagTilingData.qkHeadDim >= fagTilingData.vHeadDim) {
-            return 1 - static_cast<float>(HALF * fagTilingData.vHeadDim) / static_cast<float>(fagTilingData.qkHeadDim);
+        if (fagTilingData.qSeqlen >= fagTilingData.kvSeqlen) {
+            return 1 - static_cast<float>(HALF * fagTilingData.kvSeqlen) / static_cast<float>(fagTilingData.qSeqlen);
         } else {
-            return static_cast<float>(HALF * fagTilingData.qkHeadDim) / static_cast<float>(fagTilingData.vHeadDim);
+            return static_cast<float>(HALF * fagTilingData.qSeqlen) / static_cast<float>(fagTilingData.kvSeqlen);
         }
-    } else if (fagTilingData.maskType == static_cast<uint32_t>(MaskType::MASK_BAND)) {
-        if (fagTilingData.s1Token >= 0 && fagTilingData.s2Token >= 0) {
-            realS1 = fagTilingData.s1Token >= fagTilingData.qkHeadDim ? static_cast<float>(fagTilingData.qkHeadDim) :
-                                                             static_cast<float>(fagTilingData.s1Token);
-            realS2 = fagTilingData.s2Token >= fagTilingData.vHeadDim ? static_cast<float>(fagTilingData.vHeadDim) :
-                                                             static_cast<float>(fagTilingData.s2Token);
-            return (realS1 + realS2) / static_cast<float>(fagTilingData.qkHeadDim + fagTilingData.vHeadDim);
-        }
-        return 1.0f;
     } else {
         return 1.0f;
     }

--- a/csrc/flash_attn_npu_v3/flash_api.cpp
+++ b/csrc/flash_attn_npu_v3/flash_api.cpp
@@ -721,33 +721,20 @@ mha_bwd(at::Tensor dout,  // (b, s_q, h, dv) or (total_q, h, dv) if there is cu_
         attenMaskDevice = static_cast<uint8_t *>(const_cast<void *>(mask_gpu_tensor.storage().data()));
     }
     at::Tensor softmax_lse_kernel = softmax_lse;
-    if (!is_varlen_q) {
+        if (!is_varlen_q) {
         TORCH_CHECK(softmax_lse.dim() == 3, "mha_bwd: softmax_lse for BSND must be a 3D tensor.");
-        // Kernel CopyInSoftMax expects BSN contiguous layout:
-        // softMaxOffset = ((b * s1 + s) * nheads + h)
-        if (softmax_lse.size(1) == nheads && softmax_lse.size(2) == max_seqlen_q) {
-            // Accept BHS input and convert to BSN.
-            softmax_lse_kernel = softmax_lse.transpose(1, 2).contiguous();
-        } else {
-            TORCH_CHECK(softmax_lse.size(1) == max_seqlen_q && softmax_lse.size(2) == nheads,
-                        "mha_bwd: softmax_lse must be BSN or BHS in BSND mode.");
-            if (!softmax_lse.is_contiguous()) {
-                softmax_lse_kernel = softmax_lse.contiguous();
-            }
+        TORCH_CHECK(softmax_lse.size(1) == nheads && softmax_lse.size(2) == max_seqlen_q,
+                    "mha_bwd: softmax_lse must be BNS in BSND mode.");
+        if (!softmax_lse.is_contiguous()) {
+            softmax_lse_kernel = softmax_lse.contiguous();
         }
     } else {
         TORCH_CHECK(softmax_lse.dim() == 2, "mha_bwd: softmax_lse for TND must be a 2D tensor.");
         const int64_t total_q = qsizes[0];
-        // TND bwd kernel expects softmax_lse in TN contiguous layout.
-        if (softmax_lse.size(0) == nheads && softmax_lse.size(1) == total_q) {
-            // Accept NT input and convert to TN.
-            softmax_lse_kernel = softmax_lse.transpose(0, 1).contiguous();
-        } else {
-            TORCH_CHECK(softmax_lse.size(0) == total_q && softmax_lse.size(1) == nheads,
-                        "mha_bwd: softmax_lse must be TN or NT in TND mode.");
-            if (!softmax_lse.is_contiguous()) {
-                softmax_lse_kernel = softmax_lse.contiguous();
-            }
+        TORCH_CHECK(softmax_lse.size(0) == nheads && softmax_lse.size(1) == total_q,
+                    "mha_bwd: softmax_lse must be NT in TND mode.");
+        if (!softmax_lse.is_contiguous()) {
+            softmax_lse_kernel = softmax_lse.contiguous();
         }
     }
     auto softMaxLseDevice = static_cast<uint8_t *>(const_cast<void *>(softmax_lse_kernel.storage().data()));


### PR DESCRIPTION
## ️Related Issue
<!-- If this PR solves any issue, describe it below:
> **Example:** `fixes #1111`, `closes #1234` -->
closes #44 
closes #35

## Description
<!-- 
  Please provide a detailed summary of the changes.
  Fixed? Feat?
- What is the motivation behind this PR?
- Why is this change necessary?
-->
flash-attention-npu backward support  the shape of softmax_lse as NT/BNS

## Changes
<!-- List the key changes made in this PR -->
- [x] Changed ...
- [ ] Added ...
- [ ] Removed ...

## Additional Information
<!-- Testing, Benchmark, etc. -->
None