### PR TITLE
Feat: softcap fwd for arch22 v2/v3

### DIFF
--- a/csrc/arch22/flash_attn_npu_v2/fa_block.h
+++ b/csrc/arch22/flash_attn_npu_v2/fa_block.h
@@ -15,11 +15,12 @@ using namespace Catlass;
 
 namespace Catlass::Epilogue {
     enum class LseModeT {NONE = 0, OUT_ONLY = 1};
-    template <LseModeT LSE_MODE_, typename SM_DTYPE_>
+    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_>
     struct EpilogueAtlasA2OnlineSoftmaxT {
         using ArchTag = Arch::AtlasA2;
         using IntermPrec = SM_DTYPE_;
         static constexpr LseModeT LSE_MODE = LSE_MODE_;
+        static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
     };
 
     template <LseModeT LSE_MODE_, typename SM_DTYPE_>

--- a/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
@@ -416,7 +416,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     TORCH_CHECK(!leftpad_k_.has_value(), "NPU FlashAttention does not support leftpad_k");
     TORCH_CHECK(!rotary_cos_.has_value(), "NPU FlashAttention does not support rotary embedding");
     TORCH_CHECK(!rotary_sin_.has_value(), "NPU FlashAttention does not support rotary embedding");
-    TORCH_CHECK(softcap == 0.0f, "NPU FlashAttention does not support softcap");
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
     TORCH_CHECK(num_splits == 1 || num_splits == 0, "NPU FlashAttention only supports num_splits=1 or num_splits=0");
 
     if (k_.has_value()) {
@@ -466,7 +466,12 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     tiling_cpu_ptr->set_numBlocks(static_cast<uint32_t>(num_blocks));
     tiling_cpu_ptr->set_blockSize(static_cast<uint32_t>(page_block_size));
     tiling_cpu_ptr->set_maxNumBlocksPerBatch(static_cast<uint32_t>(max_num_blocks_per_seq));
-    tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    if (softcap > 0.0f) {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
+    } else {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    }
+    tiling_cpu_ptr->set_softcapValue(softcap);
     tiling_cpu_ptr->set_maxQSeqlen(seqlen_q);
     int32_t max_kv_seqlen = 0;
     for (int32_t i = 0; i < batch_size; i++) {
@@ -645,7 +650,7 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     // block unsupported params
     TORCH_CHECK(!alibi_slopes_.has_value(), "NPU FlashAttention does not support alibi_slopes.");
     TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
-    TORCH_CHECK(softcap == 0.0, "NPU FlashAttention does not support softcap.");
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
     TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
 
     TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
@@ -741,7 +746,12 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     } else if (is_causal) {
         tiling_cpu_ptr->set_maskType(static_cast<uint32_t>(FaiKenel::MaskType::MASK_CAUSAL));
     }
-    tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    if (softcap > 0.0f) {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
+    } else {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    }
+    tiling_cpu_ptr->set_softcapValue(softcap);
     tiling_cpu_ptr->set_maxQSeqlen(seqlen_q);
     tiling_cpu_ptr->set_mm1OutSize(mm1OutSize);
     tiling_cpu_ptr->set_smOnlineOutSize(smOnlineOutSize);
@@ -854,7 +864,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     TORCH_CHECK(!alibi_slopes_.has_value(), "NPU FlashAttention does not support alibi_slopes.");
     TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
     TORCH_CHECK(!zero_tensors, "NPU FlashAttention does not support zero_tensors.");
-    TORCH_CHECK(softcap == 0.0, "NPU FlashAttention does not support softcap.");
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
     TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
     TORCH_CHECK(k.dtype() == q.dtype(), "query and key must have the same dtype");
     TORCH_CHECK(v.dtype() == q.dtype(), "query and value must have the same dtype");
@@ -927,7 +937,12 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     } else if (is_causal) {
         tiling_cpu_ptr->set_maskType(static_cast<uint32_t>(FaiKenel::MaskType::MASK_CAUSAL));
     }
-    tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    if (softcap > 0.0f) {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
+    } else {
+        tiling_cpu_ptr->set_scaleValue(softmax_scale);
+    }
+    tiling_cpu_ptr->set_softcapValue(softcap);
     tiling_cpu_ptr->set_maxQSeqlen(max_seqlen_q);
 
     uint64_t WORKSPACE_BLOCK_SIZE_DB = 128 * 512;  // 工作空间块大小 ，每次计算128 * 512

--- a/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
@@ -466,7 +466,8 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     tiling_cpu_ptr->set_numBlocks(static_cast<uint32_t>(num_blocks));
     tiling_cpu_ptr->set_blockSize(static_cast<uint32_t>(page_block_size));
     tiling_cpu_ptr->set_maxNumBlocksPerBatch(static_cast<uint32_t>(max_num_blocks_per_seq));
-    if (softcap > 0.0f) {
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
         tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
     } else {
         tiling_cpu_ptr->set_scaleValue(softmax_scale);
@@ -608,6 +609,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     fwd_args.is_causal = is_causal;
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = flashDecodeFlag;
+    fwd_args.has_softcap = has_softcap;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -746,7 +748,8 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     } else if (is_causal) {
         tiling_cpu_ptr->set_maskType(static_cast<uint32_t>(FaiKenel::MaskType::MASK_CAUSAL));
     }
-    if (softcap > 0.0f) {
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
         tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
     } else {
         tiling_cpu_ptr->set_scaleValue(softmax_scale);
@@ -805,6 +808,7 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     fwd_args.is_causal = is_causal;
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
+    fwd_args.has_softcap = has_softcap;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -937,7 +941,8 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     } else if (is_causal) {
         tiling_cpu_ptr->set_maskType(static_cast<uint32_t>(FaiKenel::MaskType::MASK_CAUSAL));
     }
-    if (softcap > 0.0f) {
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
         tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
     } else {
         tiling_cpu_ptr->set_scaleValue(softmax_scale);
@@ -1034,6 +1039,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     fwd_args.is_causal = is_causal;
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
+    fwd_args.has_softcap = has_softcap;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;

--- a/csrc/arch22/flash_attn_npu_v2/fwd_dispatch.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fwd_dispatch.hpp
@@ -35,6 +35,7 @@ struct FwdLaunchArgs {
     bool is_causal;
     bool is_local;              // sliding-window attention (MASK_SWA)
     bool flashDecodeFlag;       // only meaningful for the BSND (kvcache) path
+    bool has_softcap;
     uint8_t *qDevice;
     uint8_t *kDevice;
     uint8_t *vDevice;

--- a/csrc/arch22/flash_attn_npu_v2/fwd_dispatch_impl.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fwd_dispatch_impl.hpp
@@ -39,6 +39,7 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
     const bool is_causal = a.is_causal;
     const bool is_local = a.is_local;
     const bool flashDecodeFlag = a.flashDecodeFlag;
+    const bool has_softcap = a.has_softcap;
     uint8_t *qDevice = a.qDevice;
     uint8_t *kDevice = a.kDevice;
     uint8_t *vDevice = a.vDevice;
@@ -54,78 +55,158 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
 
     if (paged_KV) {
         if (is_local) {
-            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
-                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                <<<blockDim, nullptr, aclStream>>>(
-                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                    qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            if (has_softcap) {
+                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            } else {
+                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            }
         } else if (is_causal) {
             // Flash-decode (8th template param = true) is a BSND-only path
             // (mha_fwd_kvcache); compiled out for TND so no FD+TND combo is
             // instantiated.
             if constexpr (!IS_TND) {
                 if (flashDecodeFlag) {
+                    if (has_softcap) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
+                } else {
+                    if (has_softcap) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
+                }
+            } else {
+                if (has_softcap) {
                     SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true>
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
                         <<<blockDim, nullptr, aclStream>>>(
                             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
                             qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
                 } else {
                     SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
                         <<<blockDim, nullptr, aclStream>>>(
                             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
                             qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
                 }
-            } else {
-                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
             }
         } else {
             if constexpr (!IS_TND) {
                 if (flashDecodeFlag) {
+                    if (has_softcap) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
+                } else {
+                    if (has_softcap) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
+                }
+            } else {
+                if (has_softcap) {
                     SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true>
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
                         <<<blockDim, nullptr, aclStream>>>(
                             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
                             qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
                 } else {
                     SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
                         <<<blockDim, nullptr, aclStream>>>(
                             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
                             qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
                 }
-            } else {
-                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
             }
         }
     } else {
         if (is_local) {
-            SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
-                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                <<<blockDim, nullptr, aclStream>>>(
-                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                    qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            if (has_softcap) {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            } else {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            }
         } else if (is_causal) {
-            SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
-                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                <<<blockDim, nullptr, aclStream>>>(
-                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                    qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            if (has_softcap) {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            } else {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            }
         } else {
-            SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
-                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY>
-                <<<blockDim, nullptr, aclStream>>>(
-                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                    qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            if (has_softcap) {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            } else {
+                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
+                    <<<blockDim, nullptr, aclStream>>>(
+                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+            }
         }
     }
 }

--- a/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
@@ -120,6 +120,7 @@ namespace SplitFuse {
             windowSizeLeft = fATilingData->windowSizeLeft;
             windowSizeRight = fATilingData->windowSizeRight;
             scaleValue = fATilingData->scaleValue;
+            softcapValue = fATilingData->softcapValue;
             maxQSeqlen = fATilingData->maxQSeqlen;
 
             // FD workspace sizing: reserve head of workspace for gLseFD/gOFD.
@@ -228,7 +229,7 @@ namespace SplitFuse {
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
 
-            epilogueOnlineSoftmax.init(resource, scaleValue);
+            epilogueOnlineSoftmax.init(resource, scaleValue, softcapValue);
             epilogueRescaleO.init(resource);
 
             coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
@@ -982,6 +983,7 @@ namespace SplitFuse {
         int64_t  windowSizeLeft;
         int64_t  windowSizeRight;
         float    scaleValue;
+        float    softcapValue;
         uint32_t totalQTokens;
         uint32_t maxQSeqlen;
 

--- a/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
@@ -1049,7 +1049,7 @@ namespace SplitFuse {
         using LayoutO = layout::RowMajor;
         using ElementLse = float;
         using LayoutLse = layout::RowMajor;
-        using ElementMask = int8_t;
+        using ElementMask = uint8_t;
         using LayoutMask = layout::RowMajor;
         using ElementOTmp = IntermCalcPrec;
         using LayoutOTmp = layout::RowMajor;

--- a/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/mha_fwd_kvcache.cpp
@@ -1016,7 +1016,8 @@ namespace SplitFuse {
         FaiKenel::MaskType maskCategory = FaiKenel::MaskType::NO_MASK,
         FaiKenel::inputLayout inLayout = FaiKenel::inputLayout::TND,
         Epilogue::LseModeT lseMode = Epilogue::LseModeT::NONE,
-        bool IS_FD = false>
+        bool IS_FD = false,
+        bool HAS_SOFTCAP = false>
     __global__ __aicore__ void FAInfer(
         uint64_t fftsAddr,
         GM_ADDR q,
@@ -1064,7 +1065,7 @@ namespace SplitFuse {
         using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK,
                                                    QType, KType, SType>;
 
-        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec>;
+        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP>;
         using PType = Gemm::GemmType<ElementP, LayoutP>;
         using maskType = Gemm::GemmType<ElementMask, LayoutMask>;
         using EpilogueOnlineSoftmax =

--- a/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
@@ -66,7 +66,7 @@ public:
     ~BlockEpilogue() {}
 
     __aicore__ inline
-    void init(Arch::Resource<ArchTag> &resource, float scaleValue_)
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_)
     {
         // Allocate UB space
         constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
@@ -74,6 +74,7 @@ public:
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
 
@@ -86,6 +87,7 @@ public:
         constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
+        softcapValue = softcapValue_;
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
@@ -100,6 +102,7 @@ public:
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
         tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -498,6 +501,38 @@ public:
             CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void ApplySoftcap(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+
+        // Clip the input to avoid overflow
+        AscendC::Maxs<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -8.8f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // (2 * softcap) / (1 + exp(-2x)) - softcap
+        AscendC::Muls<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -2.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Adds<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
+
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Div<float, false>(
+            lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Adds<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
         AscendC::PipeBarrier<PIPE_V>();
     }
 
@@ -914,6 +949,9 @@ public:
                 auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                if (softcapValue > 0.0f) {
+                    ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                }
                 SubCoreCompute<false>(
                     gOutputCurLoop,
                     layoutOutputCurLoop,
@@ -1041,6 +1079,9 @@ public:
                 
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                if (softcapValue > 0.0f) {
+                    ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                }
                 ApplyMask(
                     (pingpongFlag * MAX_UB_S_ELEM_NUM),
                     rowNumCurLoop, columnNumRound,
@@ -1220,6 +1261,9 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
@@ -1247,12 +1291,18 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                 } else if (doTriUNextMask) {
                     OperateNextMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
                               addMaskUbOffset);
                 }
@@ -1310,6 +1360,7 @@ public:
 
 private:
     float scaleValue;
+    float softcapValue;
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;
@@ -1324,6 +1375,7 @@ private:
     AscendC::LocalTensor<float> tvUbTensor;
     AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
+    AscendC::LocalTensor<float> softcapUbTensor;
 };
 
 }

--- a/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
@@ -22,15 +22,16 @@ template <
     class OutputType_,
     class InputType_,
     class MaskType_,
-    LseModeT LSE_MODE_>
+    LseModeT LSE_MODE_,
+    bool HAS_SOFTCAP_>
 class BlockEpilogue<
-    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float>,
+    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>,
     OutputType_,
     InputType_,
     MaskType_>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float>;
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
     using ElementOutput = typename OutputType_::Element;
     using ElementInput = typename InputType_::Element;
@@ -949,7 +950,7 @@ public:
                 auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                if (softcapValue > 0.0f) {
+                if constexpr (HAS_SOFTCAP_) {
                     ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 }
                 SubCoreCompute<false>(
@@ -1079,7 +1080,7 @@ public:
                 
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                if (softcapValue > 0.0f) {
+                if constexpr (HAS_SOFTCAP_) {
                     ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 }
                 ApplyMask(
@@ -1261,7 +1262,7 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
@@ -1291,7 +1292,7 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
@@ -1300,7 +1301,7 @@ public:
                     OperateNextMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,

--- a/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
@@ -92,7 +92,6 @@ public:
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
-        maskUbTensorUint8 = resource.ubBuf.template GetBufferByByte<uint8_t>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
@@ -416,7 +415,7 @@ public:
             columnNumRound
         );
         AscendC::CompareScalar(
-            maskUbTensorUint8,
+            maskUbTensor,
             maskUbTensor16,
             static_cast<half>(1.0),
             AscendC::CMPMODE::NE,
@@ -427,7 +426,7 @@ public:
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensorUint8, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
+        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
         AscendC::PipeBarrier<PIPE_V>();
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
     }
@@ -1365,7 +1364,6 @@ private:
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;
-    AscendC::LocalTensor<uint8_t> maskUbTensorUint8;
     AscendC::LocalTensor<half> maskUbTensor16;
     AscendC::LocalTensor<float> maskUbTensor32;
     AscendC::LocalTensor<float> lmUbTensor;

--- a/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
@@ -74,18 +74,16 @@ public:
         constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
-
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
-
-        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
@@ -94,6 +92,7 @@ public:
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
@@ -101,8 +100,6 @@ public:
         llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
-        tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
-        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -408,27 +405,15 @@ public:
 
     __aicore__ inline void OperatePreMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
     {
-        UpCastMask<half, ElementMask>(
-            maskUbTensor16,
-            maskUbTensor,
-            rowNumCurLoop,
-            columnNumRound
-        );
-        AscendC::CompareScalar(
-            maskUbTensor,
-            maskUbTensor16,
-            static_cast<half>(1.0),
-            AscendC::CMPMODE::NE,
-            REPEAT_SIZE_IN_BYTE / sizeof(half),
-            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
-            AscendC::UnaryRepeatParams(1, 1, 8, 8)
-        );
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
+        UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+        // 0 -> 1, 1 -> 0
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+        AscendC::Adds<float, false>(maskUbTensor32, maskUbTensor32, -1.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Abs<float, false>(maskUbTensor32, maskUbTensor32, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
     }
 
     __aicore__ inline void OperateNextMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
@@ -525,11 +510,11 @@ public:
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
 
-        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Div<float, false>(
             lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
-            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 0, 8));
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
@@ -1076,7 +1061,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
                 UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
                 UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
-                
+
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 if constexpr (HAS_SOFTCAP_) {
@@ -1256,8 +1241,9 @@ public:
                 uint32_t rowNumCurLoop =
                     (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
 
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);    
                 if (doTriUPreMask && doTriUNextMask) {
+                    // *** TriUPreMask
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
@@ -1267,26 +1253,25 @@ public:
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                    if (doTriUNextMask) {
-                        uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
-                        // the token num of the prologue part
-                        uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
-                                               tokenNumPerHeadThisSubBlock;
-                        // the token num of the epilogue part
-                        uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
-                        // the number of integral heads within a cycle
-                        uint32_t epiTokenNum =
-                            rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                        CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
-                                       tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
-                                       epiTokenNum, true);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        OperateNextMaskUb(rowNumCurLoop, columnNumRound);
-                        ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
-                                  addMaskUbOffset);
-                    }
+                    // *** TriUNextMask
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
+                                            tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum =
+                        rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                    CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
+                                    tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
+                                    epiTokenNum, true);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                    ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
+                                addMaskUbOffset);
                 } else if (doTriUPreMask) {
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
@@ -1372,7 +1357,6 @@ private:
     AscendC::LocalTensor<float> dmUbTensor;
     AscendC::LocalTensor<float> llUbTensor;
     AscendC::LocalTensor<float> tvUbTensor;
-    AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
     AscendC::LocalTensor<float> softcapUbTensor;
 };

--- a/csrc/arch22/flash_attn_npu_v2/rescale_o.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/rescale_o.hpp
@@ -86,8 +86,8 @@ public:
         // Allocate UB space
         constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
 
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
@@ -102,7 +102,7 @@ public:
         goUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(GO_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
-        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
+        lseUbTensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
     }
 
     __aicore__ inline
@@ -141,7 +141,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -157,7 +157,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -519,15 +519,15 @@ public:
                 if (isLastRowLoop) {
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Ln<float, false>(
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
                         glUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Add<float, false>(
-                        lse32_ubuf_tensor,
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
+                        lseUbTensor,
                         gmUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -536,7 +536,7 @@ public:
                     // *** lse_block = expand_to_block(lse)
                     AscendC::Brcb(
                         tvUbTensor.ReinterpretCast<uint32_t>(),
-                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        lseUbTensor.ReinterpretCast<uint32_t>(),
                         CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                         AscendC::BrcbRepeatParams(1, 8));
                     InvalidLineLSEProcess(qNThisSubBlock, delStartRow, qSBlockIdx,
@@ -567,7 +567,7 @@ public:
                         if (qNThisSubBlock == 0U) {
                             // single head: its tokens are contiguous in BNS/NT -> plain lse32 burst.
                             AscendC::DataCopyPad(
-                                gLse, lse32_ubuf_tensor,
+                                gLse, lseUbTensor,
                                 AscendC::DataCopyExtParams(1, totalRowNum * sizeof(float), 0, 0, 0));
                         } else {
                             // multi-head: per-token gather (srcStride) + scatter (dstStride).
@@ -592,15 +592,15 @@ public:
                     if (isLastRowLoop) {
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Ln<float, false>(
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
                             glUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Add<float, false>(
-                            lse32_ubuf_tensor,
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
+                            lseUbTensor,
                             gmUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -608,7 +608,7 @@ public:
 
                         AscendC::Brcb(
                             tvUbTensor.ReinterpretCast<uint32_t>(),
-                            lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                            lseUbTensor.ReinterpretCast<uint32_t>(),
                             CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                             AscendC::BrcbRepeatParams(1, 8));
                         AscendC::PipeBarrier<PIPE_V>();
@@ -801,7 +801,7 @@ private:
     AscendC::LocalTensor<ElementOutput> goUbTensor16;
     AscendC::LocalTensor<float> goUbTensor32;
     AscendC::LocalTensor<float> gmUbTensor;
-    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+    AscendC::LocalTensor<float> lseUbTensor;
 };
 
 }

--- a/csrc/arch22/flash_attn_npu_v2/tilingdata.h
+++ b/csrc/arch22/flash_attn_npu_v2/tilingdata.h
@@ -51,6 +51,7 @@ struct FAInferTilingData {
     uint64_t UpdateSize;
     uint64_t workSpaceSize;
     float scaleValue;
+    float softcapValue;
     uint64_t padding1;
     uint64_t padding2;
     uint32_t padding3;
@@ -84,6 +85,7 @@ struct FAInferTilingData {
     uint64_t get_UpdateSize() const { return UpdateSize; }
     uint64_t get_workSpaceSize() const { return workSpaceSize; }
     float get_scaleValue() const { return scaleValue; }
+    float get_softcapValue() const { return softcapValue; }
     uint64_t get_padding1() const { return padding1; }
     uint64_t get_padding2() const { return padding2; }
     uint32_t get_padding3() const { return padding3; }
@@ -113,6 +115,7 @@ struct FAInferTilingData {
     void set_UpdateSize(uint64_t value) { UpdateSize = value; }
     void set_workSpaceSize(uint64_t value) { workSpaceSize = value; }
     void set_scaleValue(float value) { scaleValue = value; }
+    void set_softcapValue(float value) { softcapValue = value; }
     void set_padding1(uint64_t value) { padding1 = value; }
     void set_padding2(uint64_t value) { padding2 = value; }
     void set_padding3(uint32_t value) { padding3 = value; }

--- a/csrc/arch22/flash_attn_npu_v3/fa_block.h
+++ b/csrc/arch22/flash_attn_npu_v3/fa_block.h
@@ -15,11 +15,12 @@ using namespace Catlass;
 
 namespace Catlass::Epilogue {
     enum class LseModeT {NONE = 0, OUT_ONLY = 1};
-    template <LseModeT LSE_MODE_, typename SM_DTYPE_>
+    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_>
     struct EpilogueAtlasA2OnlineSoftmaxT {
         using ArchTag = Arch::AtlasA2;
         using IntermPrec = SM_DTYPE_;
         static constexpr LseModeT LSE_MODE = LSE_MODE_;
+        static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
     };
 
     template <LseModeT LSE_MODE_, typename SM_DTYPE_>

--- a/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
@@ -154,7 +154,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     TORCH_CHECK(!q_descale_.has_value(), "NPU FlashAttention does not support q_descale");
     TORCH_CHECK(!k_descale_.has_value(), "NPU FlashAttention does not support k_descale");
     TORCH_CHECK(!v_descale_.has_value(), "NPU FlashAttention does not support v_descale");
-    TORCH_CHECK(softcap == 0.0f, "NPU FlashAttention does not support softcap");
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
     TORCH_CHECK(attention_chunk == 0, "NPU FlashAttention does not support attention_chunk");
     TORCH_CHECK(num_splits >= 0 && num_splits <= static_cast<int64_t>(blockDim),
                 "NPU FlashAttention supports num_splits in [0, ", blockDim,
@@ -287,7 +287,12 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         tiling_cpu_ptr->set_numBlocks(static_cast<uint32_t>(num_blocks));
         tiling_cpu_ptr->set_blockSize(static_cast<uint32_t>(page_block_size));
         tiling_cpu_ptr->set_maxNumBlocksPerBatch(static_cast<uint32_t>(max_num_blocks_per_seq));
-        tiling_cpu_ptr->set_scaleValue(softmax_scale);
+        if (softcap > 0.0f) {
+            tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
+        } else {
+            tiling_cpu_ptr->set_scaleValue(softmax_scale);
+        }
+        tiling_cpu_ptr->set_softcapValue(softcap);
         tiling_cpu_ptr->set_maxQSeqlen(seqlen_q);
         int32_t max_kv_seqlen = 0;
         for (int32_t i = 0; i < batch_size; i++) {

--- a/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
@@ -238,6 +238,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     uint8_t *maskDevice = nullptr;
     bool flashDecodeFlag = false;
     bool is_local = false;
+    bool has_softcap = (softcap > 0.0f);
 
     at::Tensor softmaxlse = at::empty({batch_size, num_heads, seqlen_q}, at::device(at::kPrivateUse1).dtype(at::kFloat));
     if (is_varlen_q) {
@@ -287,7 +288,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         tiling_cpu_ptr->set_numBlocks(static_cast<uint32_t>(num_blocks));
         tiling_cpu_ptr->set_blockSize(static_cast<uint32_t>(page_block_size));
         tiling_cpu_ptr->set_maxNumBlocksPerBatch(static_cast<uint32_t>(max_num_blocks_per_seq));
-        if (softcap > 0.0f) {
+        if (has_softcap) {
             tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
         } else {
             tiling_cpu_ptr->set_scaleValue(softmax_scale);
@@ -458,6 +459,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     fwd_args.is_causal = is_causal;
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = flashDecodeFlag;
+    fwd_args.has_softcap = has_softcap;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;

--- a/csrc/arch22/flash_attn_npu_v3/fwd_dispatch.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/fwd_dispatch.hpp
@@ -32,6 +32,7 @@ struct FwdLaunchArgs {
     bool is_causal;
     bool is_local;              // sliding-window attention (MASK_SWA)
     bool flashDecodeFlag;
+    bool has_softcap;
     uint8_t *qDevice;
     uint8_t *kDevice;
     uint8_t *vDevice;

--- a/csrc/arch22/flash_attn_npu_v3/fwd_dispatch_impl.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/fwd_dispatch_impl.hpp
@@ -33,12 +33,12 @@
 #include "mha_fwd_kvcache.cpp"
 
 // 7-param FAInfer (no IS_FD template arg — main moved flash-decode to tiling).
-#define FWD_LAUNCH(DTYPE, PAGED, MASK, LAYOUT)                                     \
+#define FWD_LAUNCH(DTYPE, PAGED, MASK, LAYOUT, SOFTCAP)                            \
     SplitFuse::FAInfer<DTYPE, DTYPE, float, PAGED,                                 \
                        FaiKenel::MaskType::MASK, FaiKenel::inputLayout::LAYOUT,    \
-                       Catlass::Epilogue::LseModeT::OUT_ONLY>                      \
+                       Catlass::Epilogue::LseModeT::OUT_ONLY, SOFTCAP>             \
         <<<launchBlockDim, nullptr, aclStream>>>(                                  \
-            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice,      \
+            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice,     \
             oDevice, softmaxLseDevice, qSeqDevice, kvSeqDevice,                    \
             workspaceDevice, tilingDevice)
 
@@ -56,6 +56,7 @@ void launch_fwd_dtype(const FwdLaunchArgs &a) {
     const bool is_causal = a.is_causal;
     const bool is_local = a.is_local;
     const bool flashDecodeFlag = a.flashDecodeFlag;
+    const bool has_softcap = a.has_softcap;
     uint8_t *qDevice = a.qDevice;
     uint8_t *kDevice = a.kDevice;
     uint8_t *vDevice = a.vDevice;
@@ -72,41 +73,89 @@ void launch_fwd_dtype(const FwdLaunchArgs &a) {
     if (paged_KV) {
         if (is_local) {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, true, MASK_SWA, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, MASK_SWA, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, MASK_SWA, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, true, MASK_SWA, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, MASK_SWA, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, MASK_SWA, BSND, false);
+                }
             }
         } else if (is_causal) {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, true, MASK_CAUSAL, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, MASK_CAUSAL, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, MASK_CAUSAL, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, true, MASK_CAUSAL, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, MASK_CAUSAL, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, MASK_CAUSAL, BSND, false);
+                }
             }
         } else {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, true, NO_MASK, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, NO_MASK, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, NO_MASK, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, true, NO_MASK, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, true, NO_MASK, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, true, NO_MASK, BSND, false);
+                }
             }
         }
     } else {
         if (is_local) {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, false, MASK_SWA, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, MASK_SWA, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, MASK_SWA, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, false, MASK_SWA, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, MASK_SWA, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, MASK_SWA, BSND, false);
+                }
             }
         } else if (is_causal) {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, false, MASK_CAUSAL, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, MASK_CAUSAL, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, MASK_CAUSAL, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, false, MASK_CAUSAL, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, MASK_CAUSAL, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, MASK_CAUSAL, BSND, false);
+                }
             }
         } else {
             if constexpr (IS_TND) {
-                FWD_LAUNCH(DType, false, NO_MASK, TND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, NO_MASK, TND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, NO_MASK, TND, false);
+                }
             } else {
-                FWD_LAUNCH(DType, false, NO_MASK, BSND);
+                if (has_softcap) {
+                    FWD_LAUNCH(DType, false, NO_MASK, BSND, true);
+                } else {
+                    FWD_LAUNCH(DType, false, NO_MASK, BSND, false);
+                }
             }
         }
     }

--- a/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
@@ -1015,7 +1015,8 @@ namespace SplitFuse {
         bool PagedCacheFlag = false,
         FaiKenel::MaskType maskCategory = FaiKenel::MaskType::NO_MASK,
         FaiKenel::inputLayout inLayout = FaiKenel::inputLayout::TND,
-        Epilogue::LseModeT lseMode = Epilogue::LseModeT::NONE>
+        Epilogue::LseModeT lseMode = Epilogue::LseModeT::NONE,
+        bool HAS_SOFTCAP = false>
     __global__ __aicore__ void FAInfer(
         uint64_t fftsAddr,
         GM_ADDR q,
@@ -1063,7 +1064,7 @@ namespace SplitFuse {
         using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK,
                                                    QType, KType, SType>;
 
-        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec>;
+        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP>;
         using PType = Gemm::GemmType<ElementP, LayoutP>;
         using maskType = Gemm::GemmType<ElementMask, LayoutMask>;
         using EpilogueOnlineSoftmax =

--- a/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
@@ -119,6 +119,7 @@ namespace SplitFuse {
             windowSizeLeft = fATilingData->windowSizeLeft;
             windowSizeRight = fATilingData->windowSizeRight;
             scaleValue = fATilingData->scaleValue;
+            softcapValue = fATilingData->softcapValue;
             maxQSeqlen = fATilingData->maxQSeqlen;
             flashDecodeFlag = fATilingData->flashDecodeFlag;
 
@@ -230,7 +231,7 @@ namespace SplitFuse {
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
 
-            epilogueOnlineSoftmax.init(resource, scaleValue);
+            epilogueOnlineSoftmax.init(resource, scaleValue, softcapValue);
             epilogueRescaleO.init(resource);
 
             coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
@@ -981,6 +982,7 @@ namespace SplitFuse {
         int64_t  windowSizeLeft;
         int64_t  windowSizeRight;
         float    scaleValue;
+        float    softcapValue;
         uint32_t totalQTokens;
         uint32_t maxQSeqlen;
         uint32_t flashDecodeFlag;

--- a/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/mha_fwd_kvcache.cpp
@@ -1048,7 +1048,7 @@ namespace SplitFuse {
         using LayoutO = layout::RowMajor;
         using ElementLse = float;
         using LayoutLse = layout::RowMajor;
-        using ElementMask = int8_t;
+        using ElementMask = uint8_t;
         using LayoutMask = layout::RowMajor;
         using ElementOTmp = IntermCalcPrec;
         using LayoutOTmp = layout::RowMajor;

--- a/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
@@ -66,7 +66,7 @@ public:
     ~BlockEpilogue() {}
 
     __aicore__ inline
-    void init(Arch::Resource<ArchTag> &resource, float scaleValue_)
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_)
     {
         // Allocate UB space
         constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
@@ -74,6 +74,7 @@ public:
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
 
@@ -86,6 +87,7 @@ public:
         constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
+        softcapValue = softcapValue_;
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
@@ -100,6 +102,7 @@ public:
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
         tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -498,6 +501,38 @@ public:
             CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void ApplySoftcap(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+
+        // Clip the input to avoid overflow
+        AscendC::Maxs<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -8.8f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // (2 * softcap) / (1 + exp(-2x)) - softcap
+        AscendC::Muls<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -2.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Adds<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
+
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Div<float, false>(
+            lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Adds<float, false>(
+            lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
         AscendC::PipeBarrier<PIPE_V>();
     }
 
@@ -914,6 +949,9 @@ public:
                 auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                if (softcapValue > 0.0f) {
+                    ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                }
                 SubCoreCompute<false>(
                     gOutputCurLoop,
                     layoutOutputCurLoop,
@@ -1041,6 +1079,9 @@ public:
                 
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                if (softcapValue > 0.0f) {
+                    ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                }
                 ApplyMask(
                     (pingpongFlag * MAX_UB_S_ELEM_NUM),
                     rowNumCurLoop, columnNumRound,
@@ -1220,6 +1261,9 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
@@ -1247,12 +1291,18 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                 } else if (doTriUNextMask) {
                     OperateNextMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    if (softcapValue > 0.0f) {
+                        ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
                               addMaskUbOffset);
                 }
@@ -1310,6 +1360,7 @@ public:
 
 private:
     float scaleValue;
+    float softcapValue;
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;
@@ -1324,6 +1375,7 @@ private:
     AscendC::LocalTensor<float> tvUbTensor;
     AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
+    AscendC::LocalTensor<float> softcapUbTensor;
 };
 
 }

--- a/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
@@ -22,15 +22,16 @@ template <
     class OutputType_,
     class InputType_,
     class MaskType_,
-    LseModeT LSE_MODE_>
+    LseModeT LSE_MODE_,
+    bool HAS_SOFTCAP_>
 class BlockEpilogue<
-    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float>,
+    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>,
     OutputType_,
     InputType_,
     MaskType_>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float>;
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
     using ElementOutput = typename OutputType_::Element;
     using ElementInput = typename InputType_::Element;
@@ -949,7 +950,7 @@ public:
                 auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                if (softcapValue > 0.0f) {
+                if constexpr (HAS_SOFTCAP_) {
                     ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 }
                 SubCoreCompute<false>(
@@ -1079,7 +1080,7 @@ public:
                 
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                if (softcapValue > 0.0f) {
+                if constexpr (HAS_SOFTCAP_) {
                     ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 }
                 ApplyMask(
@@ -1261,7 +1262,7 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
@@ -1291,7 +1292,7 @@ public:
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
@@ -1300,7 +1301,7 @@ public:
                     OperateNextMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
-                    if (softcapValue > 0.0f) {
+                    if constexpr (HAS_SOFTCAP_) {
                         ApplySoftcap((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                     }
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,

--- a/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
@@ -92,7 +92,6 @@ public:
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
-        maskUbTensorUint8 = resource.ubBuf.template GetBufferByByte<uint8_t>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
@@ -416,7 +415,7 @@ public:
             columnNumRound
         );
         AscendC::CompareScalar(
-            maskUbTensorUint8,
+            maskUbTensor,
             maskUbTensor16,
             static_cast<half>(1.0),
             AscendC::CMPMODE::NE,
@@ -427,7 +426,7 @@ public:
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensorUint8, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
+        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
         AscendC::PipeBarrier<PIPE_V>();
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
     }
@@ -1365,7 +1364,6 @@ private:
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;
-    AscendC::LocalTensor<uint8_t> maskUbTensorUint8;
     AscendC::LocalTensor<half> maskUbTensor16;
     AscendC::LocalTensor<float> maskUbTensor32;
     AscendC::LocalTensor<float> lmUbTensor;

--- a/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
@@ -74,18 +74,16 @@ public:
         constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
-
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
-
-        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
@@ -94,6 +92,7 @@ public:
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
@@ -101,8 +100,6 @@ public:
         llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
-        tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
-        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -408,27 +405,15 @@ public:
 
     __aicore__ inline void OperatePreMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
     {
-        UpCastMask<half, ElementMask>(
-            maskUbTensor16,
-            maskUbTensor,
-            rowNumCurLoop,
-            columnNumRound
-        );
-        AscendC::CompareScalar(
-            maskUbTensor,
-            maskUbTensor16,
-            static_cast<half>(1.0),
-            AscendC::CMPMODE::NE,
-            REPEAT_SIZE_IN_BYTE / sizeof(half),
-            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
-            AscendC::UnaryRepeatParams(1, 1, 8, 8)
-        );
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
+        UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+        // 0 -> 1, 1 -> 0
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+        AscendC::Adds<float, false>(maskUbTensor32, maskUbTensor32, -1.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Abs<float, false>(maskUbTensor32, maskUbTensor32, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
     }
 
     __aicore__ inline void OperateNextMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
@@ -525,11 +510,11 @@ public:
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
 
-        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Div<float, false>(
             lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
-            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 0, 8));
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
@@ -1076,7 +1061,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
                 UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
                 UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
-                
+
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 if constexpr (HAS_SOFTCAP_) {
@@ -1256,8 +1241,9 @@ public:
                 uint32_t rowNumCurLoop =
                     (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
 
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);    
                 if (doTriUPreMask && doTriUNextMask) {
+                    // *** TriUPreMask
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
@@ -1267,26 +1253,25 @@ public:
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                    if (doTriUNextMask) {
-                        uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
-                        // the token num of the prologue part
-                        uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
-                                               tokenNumPerHeadThisSubBlock;
-                        // the token num of the epilogue part
-                        uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
-                        // the number of integral heads within a cycle
-                        uint32_t epiTokenNum =
-                            rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                        CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
-                                       tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
-                                       epiTokenNum, true);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        OperateNextMaskUb(rowNumCurLoop, columnNumRound);
-                        ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
-                                  addMaskUbOffset);
-                    }
+                    // *** TriUNextMask
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
+                                            tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum =
+                        rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                    CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
+                                    tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
+                                    epiTokenNum, true);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                    ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
+                                addMaskUbOffset);
                 } else if (doTriUPreMask) {
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
@@ -1372,7 +1357,6 @@ private:
     AscendC::LocalTensor<float> dmUbTensor;
     AscendC::LocalTensor<float> llUbTensor;
     AscendC::LocalTensor<float> tvUbTensor;
-    AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
     AscendC::LocalTensor<float> softcapUbTensor;
 };

--- a/csrc/arch22/flash_attn_npu_v3/rescale_o.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/rescale_o.hpp
@@ -86,8 +86,8 @@ public:
         // Allocate UB space
         constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
 
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
@@ -102,7 +102,7 @@ public:
         goUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(GO_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
-        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
+        lseUbTensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
     }
 
     __aicore__ inline
@@ -141,7 +141,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -157,7 +157,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -519,15 +519,15 @@ public:
                 if (isLastRowLoop) {
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Ln<float, false>(
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
                         glUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Add<float, false>(
-                        lse32_ubuf_tensor,
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
+                        lseUbTensor,
                         gmUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -536,7 +536,7 @@ public:
                     // *** lse_block = expand_to_block(lse)
                     AscendC::Brcb(
                         tvUbTensor.ReinterpretCast<uint32_t>(),
-                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        lseUbTensor.ReinterpretCast<uint32_t>(),
                         CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                         AscendC::BrcbRepeatParams(1, 8));
                     InvalidLineLSEProcess(qNThisSubBlock, delStartRow, qSBlockIdx,
@@ -567,7 +567,7 @@ public:
                         if (qNThisSubBlock == 0U) {
                             // single head: its tokens are contiguous in BNS/NT -> plain lse32 burst.
                             AscendC::DataCopyPad(
-                                gLse, lse32_ubuf_tensor,
+                                gLse, lseUbTensor,
                                 AscendC::DataCopyExtParams(1, totalRowNum * sizeof(float), 0, 0, 0));
                         } else {
                             // multi-head: per-token gather (srcStride) + scatter (dstStride).
@@ -592,15 +592,15 @@ public:
                     if (isLastRowLoop) {
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Ln<float, false>(
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
                             glUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Add<float, false>(
-                            lse32_ubuf_tensor,
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
+                            lseUbTensor,
                             gmUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -608,7 +608,7 @@ public:
 
                         AscendC::Brcb(
                             tvUbTensor.ReinterpretCast<uint32_t>(),
-                            lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                            lseUbTensor.ReinterpretCast<uint32_t>(),
                             CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                             AscendC::BrcbRepeatParams(1, 8));
                         AscendC::PipeBarrier<PIPE_V>();
@@ -802,7 +802,7 @@ private:
     AscendC::LocalTensor<ElementOutput> goUbTensor16;
     AscendC::LocalTensor<float> goUbTensor32;
     AscendC::LocalTensor<float> gmUbTensor;
-    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+    AscendC::LocalTensor<float> lseUbTensor;
 };
 
 }

--- a/csrc/arch22/flash_attn_npu_v3/tilingdata.h
+++ b/csrc/arch22/flash_attn_npu_v3/tilingdata.h
@@ -51,6 +51,7 @@ struct FAInferTilingData {
     uint64_t UpdateSize;
     uint64_t workSpaceSize;
     float scaleValue;
+    float softcapValue;
     uint64_t padding1;
     uint64_t padding2;
     uint32_t padding3;
@@ -84,6 +85,7 @@ struct FAInferTilingData {
     uint64_t get_UpdateSize() const { return UpdateSize; }
     uint64_t get_workSpaceSize() const { return workSpaceSize; }
     float get_scaleValue() const { return scaleValue; }
+    float get_softcapValue() const { return softcapValue; }
     uint64_t get_padding1() const { return padding1; }
     uint64_t get_padding2() const { return padding2; }
     uint32_t get_padding3() const { return padding3; }
@@ -116,6 +118,7 @@ struct FAInferTilingData {
     void set_UpdateSize(uint64_t value) { UpdateSize = value; }
     void set_workSpaceSize(uint64_t value) { workSpaceSize = value; }
     void set_scaleValue(float value) { scaleValue = value; }
+    void set_softcapValue(float value) { softcapValue = value; }
     void set_padding1(uint64_t value) { padding1 = value; }
     void set_padding2(uint64_t value) { padding2 = value; }
     void set_padding3(uint32_t value) { padding3 = value; }

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -88,6 +88,7 @@ def ref_flash_attention(
     scale,
     mask,
     data_type,
+    softcap,
     ):
     inner_prec = 0
     interm_dtype = torch.float16 if inner_prec == 1 else torch.float32
@@ -116,6 +117,8 @@ def ref_flash_attention(
         sub_value = value[:, kv_start: kv_start + sub_len, :]
         qk_result = qkMM1(query, sub_key).to(interm_dtype)
         qk_result = qk_result * scale
+        if softcap > 0.0:
+            qk_result = softcap * torch.tanh(qk_result / softcap)
         if mask is not None:
             qk_result += sub_mask
         if kv_start == 0:
@@ -140,112 +143,119 @@ def ref_flash_attention(
     return go.to(data_type), lse
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right)
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 0, 128, True, -1, -1),
-    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1),
-    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap)
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 0, 128, True, -1, -1, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, -1, -1, 0.0),
     # kv=4096 -> 8 S2 blocks: num_splits=2 -> 2 segs (4 blk each), num_splits=4 -> 4 segs (2 blk each).
-    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, -1, -1),
-    (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, 512, 0),# Mistral-style causal SWA
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, 512, 256),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 0, 128, True, -128, 864),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, 0, 256),
-    (torch.float16, 2, 2, 2, 512, 512, 128, 0, 128, False, 64, 128),
+    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, 512, 0, 0.0),  # Mistral-style causal SWA
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, 512, 256, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 0, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, 0, 256, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, 0, 128, False, 64, 128, 0.0),
 
-    (torch.bfloat16, 1, 8, 2, 1, 512, 128, 0, 128, True, -1, -1),
-    (torch.bfloat16, 4, 32, 8, 1, 2048, 128, 0, 128, False, -1, -1), # g=4,decode, qNBlockTile=4
-    (torch.bfloat16, 8, 64, 8, 1, 4096, 128, 0, 128, False, -1, -1), # g=8,decode, qNBlockTile=8
-    (torch.bfloat16, 4, 64, 16, 16, 1024, 128, 0, 128, True, -1, -1),# g=4,Sq=16,qNBlockTile=4
-    (torch.bfloat16, 8, 128, 16, 32, 2048, 128, 0, 128, False, -1, -1),# g=8,Sq=32,qNBlockTile=4
-    (torch.bfloat16, 4, 64, 8, 64, 4096, 128, 0, 128, False, -1, -1),# g=8,Sq=64,qNBlockTile=2
-    (torch.bfloat16, 8, 128, 8, 1, 4096, 128, 0, 128, False, -1, -1),# g=16, decode, qNBlockTile=16
-    (torch.bfloat16, 4, 32, 4, 16, 1024, 256, 0, 128, False, -1, -1),# g=8,Sq=16,D=256
-    (torch.bfloat16, 8, 128, 32, 64, 2048, 128, 0, 128, True, -1, -1), # g=4,Sq=64,qNBlockTile=2
-    (torch.bfloat16, 4, 64, 4, 32, 512, 128, 0, 128, False, -1, -1), # g=16, Sq=32,qNBlockTile=4
-    (torch.bfloat16, 2, 64, 8, 1, 4096, 256, 0, 128, False, -1, -1), # g=8,decode, D=256
-    (torch.bfloat16, 1, 32, 4, 1, 2048, 128, 1, 128, False, -1, -1), # FD decode, g=8,nT=4
-    (torch.bfloat16, 1, 64, 4, 1, 4096, 128, 1, 128, False, -1, -1), # FD decode, g=16, nT=4
-    (torch.bfloat16, 1, 128, 4, 1, 2048, 128, 1, 128, True, -1, -1), # FD decode, g=32, nT=4
-    (torch.bfloat16, 2, 32, 4, 1, 4096, 128, 1, 128, False, -1, -1), # FD decode, g=8,nT=8
-    (torch.bfloat16, 2, 16, 2, 1, 2048, 128, 1, 128, True, -1, -1),# FD decode, g=8,nT=4
-    (torch.bfloat16, 1, 32, 8, 1, 2048, 256, 1, 128, False, -1, -1), # FD decode, g=4,nT=8, D=256
-    (torch.bfloat16, 1, 32, 4, 4, 2048, 128, 1, 128, False, -1, -1), # FD multi, g=8,Sq*g=32,nT=4
-    (torch.bfloat16, 2, 16, 2, 4, 4096, 128, 1, 128, False, -1, -1), # FD multi, g=8,Sq*g=32,nT=4
-    (torch.bfloat16, 1, 64, 4, 8, 2048, 128, 1, 128, True, -1, -1),# FD multi, g=16, Sq*g=128, nT=4
-    (torch.bfloat16, 1, 32, 4, 16, 4096, 128, 1, 128, False, -1, -1),# FD multi, g=8,Sq*g=128, nT=4
+    (torch.bfloat16, 1, 8, 2, 1, 512, 128, 0, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 8, 1, 2048, 128, 0, 128, False, -1, -1, 0.0), # g=4,decode, qNBlockTile=4
+    (torch.bfloat16, 8, 64, 8, 1, 4096, 128, 0, 128, False, -1, -1, 0.0), # g=8,decode, qNBlockTile=8
+    (torch.bfloat16, 4, 64, 16, 16, 1024, 128, 0, 128, True, -1, -1, 0.0),# g=4,Sq=16,qNBlockTile=4
+    (torch.bfloat16, 8, 128, 16, 32, 2048, 128, 0, 128, False, -1, -1, 0.0),# g=8,Sq=32,qNBlockTile=4
+    (torch.bfloat16, 4, 64, 8, 64, 4096, 128, 0, 128, False, -1, -1, 0.0),# g=8,Sq=64,qNBlockTile=2
+    (torch.bfloat16, 8, 128, 8, 1, 4096, 128, 0, 128, False, -1, -1, 0.0),# g=16, decode, qNBlockTile=16
+    (torch.bfloat16, 4, 32, 4, 16, 1024, 256, 0, 128, False, -1, -1, 0.0),# g=8,Sq=16,D=256
+    (torch.bfloat16, 8, 128, 32, 64, 2048, 128, 0, 128, True, -1, -1, 0.0), # g=4,Sq=64,qNBlockTile=2
+    (torch.bfloat16, 4, 64, 4, 32, 512, 128, 0, 128, False, -1, -1, 0.0), # g=16, Sq=32,qNBlockTile=4
+    (torch.bfloat16, 2, 64, 8, 1, 4096, 256, 0, 128, False, -1, -1, 0.0), # g=8,decode, D=256
+    (torch.bfloat16, 1, 32, 4, 1, 2048, 128, 1, 128, False, -1, -1, 0.0), # FD decode, g=8,nT=4
+    (torch.bfloat16, 1, 64, 4, 1, 4096, 128, 1, 128, False, -1, -1, 0.0), # FD decode, g=16, nT=4
+    (torch.bfloat16, 1, 128, 4, 1, 2048, 128, 1, 128, True, -1, -1, 0.0), # FD decode, g=32, nT=4
+    (torch.bfloat16, 2, 32, 4, 1, 4096, 128, 1, 128, False, -1, -1, 0.0), # FD decode, g=8,nT=8
+    (torch.bfloat16, 2, 16, 2, 1, 2048, 128, 1, 128, True, -1, -1, 0.0),# FD decode, g=8,nT=4
+    (torch.bfloat16, 1, 32, 8, 1, 2048, 256, 1, 128, False, -1, -1, 0.0), # FD decode, g=4,nT=8, D=256
+    (torch.bfloat16, 1, 32, 4, 4, 2048, 128, 1, 128, False, -1, -1, 0.0), # FD multi, g=8,Sq*g=32,nT=4
+    (torch.bfloat16, 2, 16, 2, 4, 4096, 128, 1, 128, False, -1, -1, 0.0), # FD multi, g=8,Sq*g=32,nT=4
+    (torch.bfloat16, 1, 64, 4, 8, 2048, 128, 1, 128, True, -1, -1, 0.0),# FD multi, g=16, Sq*g=128, nT=4
+    (torch.bfloat16, 1, 32, 4, 16, 4096, 128, 1, 128, False, -1, -1, 0.0),# FD multi, g=8,Sq*g=128, nT=4
     
-    (torch.bfloat16, 1, 32, 4, 3, 2048, 128, 1, 128, False, -1, -1), # FD JSQ4 Sq=3,g=8,nT=4  [非2幂]
-    (torch.bfloat16, 2, 16, 2, 5, 4096, 128, 1, 128, True, -1, -1),# FD JSQ4 Sq=5,g=8,nT=4  [非2幂]
-    (torch.bfloat16, 1, 64, 4, 7, 2048, 128, 1, 128, False, -1, -1), # FD JSQ4 Sq=7,g=16, nT=4  [非2幂]
-    (torch.bfloat16, 1, 32, 4, 11, 4096, 128, 1, 128, False, -1, -1),# FD JSQ4 Sq=11, g=8,nT=4  [非2幂]
-    (torch.bfloat16, 1, 32, 8, 13, 2048, 256, 1, 128, False, -1, -1),# FD JSQ4 Sq=13, g=4,nT=8, D=256 [非2幂]
-    (torch.bfloat16, 2, 16, 2, 15, 2048, 128, 1, 128, True, -1, -1), # FD JSQ4 Sq=15, g=8,nT=4  [非2幂]
-    (torch.bfloat16, 4, 32, 32, 1, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 8, 64, 64, 1, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 32, 32, 16, 1024, 128, 0, 128, True, -1, -1),
-    (torch.bfloat16, 4, 64, 64, 32, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 8, 16, 16, 8, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 32, 32, 1, 4096, 256, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 0, 128, True, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 6, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 6, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 40, 2, 6, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 8, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 8, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 10, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 10, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 64, 2, 10, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 6, 2048, 256, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 48, 2, 8, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 2, 48, 4, 8, 2048, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 4, 64, 4, 10, 4096, 128, 0, 128, False, -1, -1),
-    (torch.bfloat16, 1, 64, 4, 2, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 2, 32, 4, 2, 4096, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 64, 8, 4, 4096, 128, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 7, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 2, 16, 2, 8, 4096, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 13, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 32, 8, 16, 2048, 256, 1, 128, False, -1, -1),
+    (torch.bfloat16, 1, 32, 4, 3, 2048, 128, 1, 128, False, -1, -1, 0.0), # FD JSQ4 Sq=3,g=8,nT=4  [非2幂]
+    (torch.bfloat16, 2, 16, 2, 5, 4096, 128, 1, 128, True, -1, -1, 0.0),# FD JSQ4 Sq=5,g=8,nT=4  [非2幂]
+    (torch.bfloat16, 1, 64, 4, 7, 2048, 128, 1, 128, False, -1, -1, 0.0), # FD JSQ4 Sq=7,g=16, nT=4  [非2幂]
+    (torch.bfloat16, 1, 32, 4, 11, 4096, 128, 1, 128, False, -1, -1, 0.0),# FD JSQ4 Sq=11, g=8,nT=4  [非2幂]
+    (torch.bfloat16, 1, 32, 8, 13, 2048, 256, 1, 128, False, -1, -1, 0.0),# FD JSQ4 Sq=13, g=4,nT=8, D=256 [非2幂]
+    (torch.bfloat16, 2, 16, 2, 15, 2048, 128, 1, 128, True, -1, -1, 0.0), # FD JSQ4 Sq=15, g=8,nT=4  [非2幂]
+    (torch.bfloat16, 4, 32, 32, 1, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 64, 64, 1, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 32, 16, 1024, 128, 0, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 4, 64, 64, 32, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 16, 16, 8, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 32, 1, 4096, 256, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 0, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 6, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 6, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 40, 2, 6, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 8, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 8, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 10, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 10, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 64, 2, 10, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 6, 2048, 256, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 48, 2, 8, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 48, 4, 8, 2048, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 64, 4, 10, 4096, 128, 0, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 64, 4, 2, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 4, 2, 4096, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 64, 8, 4, 4096, 128, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 7, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 16, 2, 8, 4096, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 13, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 8, 16, 2048, 256, 1, 128, False, -1, -1, 0.0),
     # --- JSQ4/ODD ---
-    (torch.bfloat16, 1, 6, 2, 6, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 6, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 10, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 10, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 14, 2, 10, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 18, 2, 10, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 14, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 14, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 9, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 11, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 15, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, -1, -1),
-    (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, -1, -1),
-    (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, -1, -1),
+    (torch.bfloat16, 1, 6, 2, 6, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 6, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 10, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 10, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 14, 2, 10, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 18, 2, 10, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 14, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 14, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 9, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 11, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 15, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, -1, -1, 0.0),
+    # Softcap
+    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 0, 128, False, -1, -1, 30.0),
+    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 0, 128, True, -1, -1, 50.0),
+    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 0, 128, False, -1, -1, 50.0),
+    (torch.bfloat16, 2, 24, 2, 6, 2048, 128, 0, 128, False, -1, -1, 30.0),
+    (torch.bfloat16, 4, 32, 2, 6, 4096, 128, 0, 128, False, -1, -1, 50.0),
+    (torch.bfloat16, 2, 40, 2, 6, 2048, 128, 0, 128, False, -1, -1, 50.0),
 ]
 
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right", test_cases)
-def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap):
     q_min_range = -5.0
     q_max_range = 5.0
     kv_min_range = -5.0
@@ -274,7 +284,6 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     kv_seqlen_list = [kv_seqlen] * batch_size
     scale = 1.0 / (head_size ** 0.5)
     is_rotary_interleaved = False
-    softcap = 0
     num_splits = 0
     kv_seqlen_list = torch.tensor(kv_seqlen_list, dtype=torch.int32).npu()
     rotary_cos = None
@@ -308,6 +317,7 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         block_table=block_tables,
         causal=is_causal,
         window_size=[window_size_left, window_size_right],
+        softcap=softcap,
         rotary_interleaved=is_rotary_interleaved,
         alibi_slopes=alibi_slopes,
         num_splits=num_splits,
@@ -366,9 +376,9 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
             value_cache_per_batch = value_cache.detach().cpu()[i]
         query_cpu = query.detach().cpu()[i]
         if is_causal_golden or is_local_golden:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen, num_heads, head_size)
         if is_local_golden:
             preTokens = window_size_left_golden
@@ -398,24 +408,24 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
 
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal)
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, True, False),
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap)
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
 ]
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal", test_cases)
-def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
+def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):
     q_min_range = -5.0
     q_max_range = 5.0
     kv_min_range = -5.0
@@ -431,7 +441,6 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
     scale = 1.0 / (head_size ** 0.5)
     window_size_left = -1
     window_size_right = -1
-    softcap = 0
     num_splits = 0
     alibi_slopes = None
 
@@ -442,6 +451,7 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
         0.0,
         causal=is_causal,
         window_size=[window_size_left,window_size_right],
+        softcap=softcap,
         alibi_slopes=alibi_slopes,
         return_attn_probs=return_attn_probs)
     if not return_attn_probs:
@@ -463,9 +473,9 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
 
         query_cpu = query.detach().cpu()[i]
         if is_causal:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen, num_heads, head_size)
         golden_out[i:i+1] = out
         golden_lseL[i:i+1] = golden_lse.reshape(num_heads, q_seqlen)
@@ -477,31 +487,36 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
         torch.testing.assert_close(softmax_lse.cpu(), golden_lseL.cpu(), rtol=rtol, atol=atol)
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right)
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1),
-    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1),
-    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1),
-    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1),
-    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1),
-    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap)
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 0.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 0.0),
     # SWA
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128),
-    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256),
-    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0),
-    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0),
-    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0),
-    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128, 0.0),
+    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256, 0.0),
+    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0, 0.0),
+    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0, 0.0),
+    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0),
+    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0),
+    # Softcap
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1,  30.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 50.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 30.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 50.0),
 ]
 
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right", test_cases)
-def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap):
     q_min_range = -5.0
     q_max_range = 5.0
     kv_min_range = -5.0
@@ -516,7 +531,6 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     max_seqlen_k = kv_seqlen
     dropout_p = 0.0
     scale = 1.0 / (head_size ** 0.5)
-    softcap = 0
     alibi_slopes = None
     deterministic = False
     return_attn_probs = True
@@ -577,9 +591,9 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         value_per_batch = value.detach().cpu()[(i - 1) * kv_seqlen : i * kv_seqlen]
         query_cpu = query.detach().cpu()[(i - 1) * q_seqlen : i * q_seqlen]
         if is_causal_golden or is_local_golden:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen , num_heads, head_size)
         if is_local_golden:
             preTokens = window_size_left_golden

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -423,6 +423,11 @@ test_cases = [
     (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
     (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
     (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    # Softcap
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 50.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 50.0),
 ]
 @pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
 def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -91,6 +91,7 @@ def ref_flash_attention(
     scale,
     mask,
     data_type,
+    softcap,
     ):
     inner_prec = 0
     interm_dtype = torch.float16 if inner_prec == 1 else torch.float32
@@ -119,6 +120,8 @@ def ref_flash_attention(
         sub_value = value[:, kv_start: kv_start + sub_len, :]
         qk_result = qkMM1(query, sub_key).to(interm_dtype)
         qk_result = qk_result * scale
+        if softcap > 0.0:
+            qk_result = softcap * torch.tanh(qk_result / softcap)
         if mask is not None:
             qk_result += sub_mask
         if kv_start == 0:
@@ -144,127 +147,135 @@ def ref_flash_attention(
 
 test_cases = [
     # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode,
-    #  block_size, is_causal, layout, is_varied, window_size_left, window_size_right)
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "BSND", False, -1, -1),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "BSND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "BSND", False, -1, -1),
+    #  block_size, is_causal, layout, is_varied, window_size_left, window_size_right, softcap)
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
     # kv=4096 -> 8 S2 blocks: num_splits=2 -> 2 segs (4 blk each), num_splits=4 -> 4 segs (2 blk each).
-    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 16, 1024, 128, 1, 128, False, "TND", True, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 16, 1024, 128, 1, 128, False, "TND", True, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 16, 1024, 128, 1, 128, True, "TND", True, -1, -1),
-    (torch.bfloat16, 1, 64, 1, 2, 1024, 256, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 16, 1024, 256, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 1, 1, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 6, 1, 1, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, "BSND", False, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, "TND", False, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, 0, 256),
-    (torch.float16, 2, 1, 1, 512, 512, 128, 1, 128, False, "TND", False, 508, -256),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -128, 1024),
-    (torch.float16, 2, 2, 2, 512, 512, 128, 0, 128, False, "TND", False, 64, 128),
-    (torch.bfloat16, 4, 32, 8, 1, 2048, 128, 1, 128, False, "BSND", False, -1, -1), # g=4,decode, qNBlockTile=4
-    (torch.bfloat16, 8, 64, 8, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1), # g=8,decode, qNBlockTile=8
-    (torch.bfloat16, 4, 64, 16, 16, 1024, 128, 1, 128, True, "BSND", False, -1, -1),# g=4,Sq=16,qNBlockTile=4
-    (torch.bfloat16, 8, 128, 16, 32, 2048, 128, 1, 128, False, "BSND", False, -1, -1), # g=8,Sq=32,qNBlockTile=4
-    (torch.bfloat16, 4, 64, 8, 64, 4096, 128, 1, 128, False, "BSND", False, -1, -1), # g=8,Sq=64,qNBlockTile=2
-    (torch.bfloat16, 8, 128, 8, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1), # g=16, decode, qNBlockTile=16
-    (torch.bfloat16, 4, 32, 4, 16, 1024, 256, 1, 128, False, "BSND", False, -1, -1), # g=8,Sq=16,D=256
-    (torch.bfloat16, 8, 128, 32, 64, 2048, 128, 1, 128, True, "BSND", False, -1, -1),# g=4,Sq=64,qNBlockTile=2
-    (torch.bfloat16, 4, 64, 4, 32, 512, 128, 1, 128, False, "BSND", False, -1, -1),# g=16, Sq=32,qNBlockTile=4
-    (torch.bfloat16, 2, 64, 8, 1, 4096, 256, 1, 128, False, "BSND", False, -1, -1),# g=8,decode, D=256
-    (torch.bfloat16, 4, 32, 8, 32, 2048, 128, 1, 128, False, "TND", False, -1, -1),# g=4,Sq=32, qNBlockTile=4
-    (torch.bfloat16, 8, 64, 8, 32, 4096, 128, 1, 128, False, "TND", False, -1, -1),# g=8,Sq=32, qNBlockTile=4
-    (torch.bfloat16, 4, 32, 8, 64, 4096, 128, 1, 128, False, "TND", False, -1, -1),# g=4,Sq=64, qNBlockTile=2
-    (torch.bfloat16, 8, 64, 8, 64, 2048, 128, 1, 128, True, "TND", False, -1, -1), # g=8,Sq=64, qNBlockTile=2
-    (torch.bfloat16, 4, 64, 8, 48, 2048, 128, 1, 128, False, "TND", False, -1, -1),# g=8,Sq=48, qNBlockTile=2
-    (torch.bfloat16, 4, 64, 4, 32, 1024, 128, 1, 128, False, "TND", False, -1, -1),# g=16, Sq=32, qNBlockTile=4
-    (torch.bfloat16, 4, 32, 8, 64, 2048, 256, 1, 128, False, "TND", False, -1, -1),# g=4,Sq=64, D=256
-    (torch.bfloat16, 8, 128, 16, 32, 4096, 128, 1, 128, False, "TND", False, -1, -1),# g=8,Sq=32, qNBlockTile=4
-    (torch.bfloat16, 1, 32, 4, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1), # FD decode, g=8,nT=4
-    (torch.bfloat16, 1, 64, 4, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1), # FD decode, g=16, nT=4
-    (torch.bfloat16, 1, 128, 4, 1, 2048, 128, 1, 128, True, "TND", False, -1, -1), # FD decode, g=32, nT=4
-    (torch.bfloat16, 2, 32, 4, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1), # FD decode, g=8,nT=8
-    (torch.bfloat16, 2, 16, 2, 1, 2048, 128, 1, 128, True, "TND", False, -1, -1),# FD decode, g=8,nT=4
-    (torch.bfloat16, 1, 32, 8, 1, 2048, 256, 1, 128, False, "TND", False, -1, -1), # FD decode, g=4,nT=8, D=256
-    (torch.bfloat16, 1, 32, 4, 4, 2048, 128, 1, 128, False, "TND", False, -1, -1), # FD multi, g=8,Sq*g=32,nT=4
-    (torch.bfloat16, 2, 16, 2, 4, 4096, 128, 1, 128, False, "TND", False, -1, -1), # FD multi, g=8,Sq*g=32,nT=4
-    (torch.bfloat16, 1, 64, 4, 8, 2048, 128, 1, 128, True, "TND", False, -1, -1),# FD multi, g=16, Sq*g=128, nT=4
-    (torch.bfloat16, 1, 32, 4, 16, 4096, 128, 1, 128, False, "TND", False, -1, -1),# FD multi, g=8,Sq*g=128, nT=4
-    (torch.bfloat16, 1, 32, 4, 3, 2048, 128, 1, 128, False, "TND", False, -1, -1), # FD Sq=3,g=8,nT=4  [非2幂]
-    (torch.bfloat16, 2, 16, 2, 5, 4096, 128, 1, 128, True, "TND", False, -1, -1),# FD Sq=5,g=8,nT=4  [非2幂]
-    (torch.bfloat16, 1, 64, 4, 7, 2048, 128, 1, 128, False, "TND", False, -1, -1), # FD Sq=7,g=16, nT=4  [非2幂]
-    (torch.bfloat16, 1, 32, 4, 11, 4096, 128, 1, 128, False, "TND", False, -1, -1),# FD Sq=11, g=8,nT=4  [非2幂]
-    (torch.bfloat16, 1, 32, 8, 13, 2048, 256, 1, 128, False, "TND", False, -1, -1),# FD Sq=13, g=4,nT=8, D=256 [非2幂]
-    (torch.bfloat16, 2, 16, 2, 15, 2048, 128, 1, 128, True, "TND", False, -1, -1), # FD Sq=15, g=8,nT=4  [非2幂]
-    (torch.bfloat16, 4, 32, 32, 1, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 8, 64, 64, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 32, 16, 1024, 128, 1, 128, True, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 64, 64, 32, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 8, 16, 16, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 32, 32, 1, 4096, 256, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 1, 128, True, "BSND", False, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 32, 32, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 32, 48, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 4, 64, 64, 64, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 6, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 6, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 40, 2, 6, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 8, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 10, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 32, 2, 10, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 64, 2, 10, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 24, 2, 6, 2048, 256, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 48, 2, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 2, 48, 4, 8, 2048, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 4, 64, 4, 10, 4096, 128, 1, 128, False, "BSND", False, -1, -1),
-    (torch.bfloat16, 1, 64, 4, 2, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 32, 4, 2, 4096, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 64, 8, 4, 4096, 128, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 7, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 2, 16, 2, 8, 4096, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 32, 4, 13, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 32, 8, 16, 2048, 256, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 6, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 6, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 14, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 18, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 14, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 14, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 9, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 6, 2, 11, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 15, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, "TND", False, -1, -1),
-    (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, "TND", False, -1, -1),
+        (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 16, 1024, 128, 1, 128, False, "TND", True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 16, 1024, 128, 1, 128, False, "TND", True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 16, 1024, 128, 1, 128, True, "TND", True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 64, 1, 2, 1024, 256, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 16, 1024, 256, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 1, 1, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 6, 1, 1, 16, 10240, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, "BSND", False, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, True, "TND", False, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "TND", False, 0, 256, 0.0),
+    (torch.float16, 2, 1, 1, 512, 512, 128, 1, 128, False, "TND", False, 508, -256, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 1, 128, False, "BSND", False, -128, 1024, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, 0, 128, False, "TND", False, 64, 128, 0.0),
+
+    (torch.bfloat16, 4, 32, 8, 1, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=4,decode, qNBlockTile=4
+    (torch.bfloat16, 8, 64, 8, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=8,decode, qNBlockTile=8
+    (torch.bfloat16, 4, 64, 16, 16, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),# g=4,Sq=16,qNBlockTile=4
+    (torch.bfloat16, 8, 128, 16, 32, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=8,Sq=32,qNBlockTile=4
+    (torch.bfloat16, 4, 64, 8, 64, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=8,Sq=64,qNBlockTile=2
+    (torch.bfloat16, 8, 128, 8, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=16, decode, qNBlockTile=16
+    (torch.bfloat16, 4, 32, 4, 16, 1024, 256, 1, 128, False, "BSND", False, -1, -1, 0.0), # g=8,Sq=16,D=256
+    (torch.bfloat16, 8, 128, 32, 64, 2048, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),# g=4,Sq=64,qNBlockTile=2
+    (torch.bfloat16, 4, 64, 4, 32, 512, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),# g=16, Sq=32,qNBlockTile=4
+    (torch.bfloat16, 2, 64, 8, 1, 4096, 256, 1, 128, False, "BSND", False, -1, -1, 0.0),# g=8,decode, D=256
+    (torch.bfloat16, 4, 32, 8, 32, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=4,Sq=32, qNBlockTile=4
+    (torch.bfloat16, 8, 64, 8, 32, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=8,Sq=32, qNBlockTile=4
+    (torch.bfloat16, 4, 32, 8, 64, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=4,Sq=64, qNBlockTile=2
+    (torch.bfloat16, 8, 64, 8, 64, 2048, 128, 1, 128, True, "TND", False, -1, -1, 0.0), # g=8,Sq=64, qNBlockTile=2
+    (torch.bfloat16, 4, 64, 8, 48, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=8,Sq=48, qNBlockTile=2
+    (torch.bfloat16, 4, 64, 4, 32, 1024, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=16, Sq=32, qNBlockTile=4
+    (torch.bfloat16, 4, 32, 8, 64, 2048, 256, 1, 128, False, "TND", False, -1, -1, 0.0),# g=4,Sq=64, D=256
+    (torch.bfloat16, 8, 128, 16, 32, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# g=8,Sq=32, qNBlockTile=4
+    (torch.bfloat16, 1, 32, 4, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD decode, g=8,nT=4
+    (torch.bfloat16, 1, 64, 4, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD decode, g=16, nT=4
+    (torch.bfloat16, 1, 128, 4, 1, 2048, 128, 1, 128, True, "TND", False, -1, -1, 0.0), # FD decode, g=32, nT=4
+    (torch.bfloat16, 2, 32, 4, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD decode, g=8,nT=8
+    (torch.bfloat16, 2, 16, 2, 1, 2048, 128, 1, 128, True, "TND", False, -1, -1, 0.0),# FD decode, g=8,nT=4
+    (torch.bfloat16, 1, 32, 8, 1, 2048, 256, 1, 128, False, "TND", False, -1, -1, 0.0), # FD decode, g=4,nT=8, D=256
+    (torch.bfloat16, 1, 32, 4, 4, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD multi, g=8,Sq*g=32,nT=4
+    (torch.bfloat16, 2, 16, 2, 4, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD multi, g=8,Sq*g=32,nT=4
+    (torch.bfloat16, 1, 64, 4, 8, 2048, 128, 1, 128, True, "TND", False, -1, -1, 0.0),# FD multi, g=16, Sq*g=128, nT=4
+    (torch.bfloat16, 1, 32, 4, 16, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# FD multi, g=8,Sq*g=128, nT=4
+    (torch.bfloat16, 1, 32, 4, 3, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD Sq=3,g=8,nT=4  [非2幂]
+    (torch.bfloat16, 2, 16, 2, 5, 4096, 128, 1, 128, True, "TND", False, -1, -1, 0.0),# FD Sq=5,g=8,nT=4  [非2幂]
+    (torch.bfloat16, 1, 64, 4, 7, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0), # FD Sq=7,g=16, nT=4  [非2幂]
+    (torch.bfloat16, 1, 32, 4, 11, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),# FD Sq=11, g=8,nT=4  [非2幂]
+    (torch.bfloat16, 1, 32, 8, 13, 2048, 256, 1, 128, False, "TND", False, -1, -1, 0.0),# FD Sq=13, g=4,nT=8, D=256 [非2幂]
+    (torch.bfloat16, 2, 16, 2, 15, 2048, 128, 1, 128, True, "TND", False, -1, -1, 0.0), # FD Sq=15, g=8,nT=4  [非2幂]
+    (torch.bfloat16, 4, 32, 32, 1, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 64, 64, 1, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 32, 16, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 64, 64, 32, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 16, 16, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 32, 1, 4096, 256, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 32, 32, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 32, 48, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 64, 64, 64, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 8, 65, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 64, 16, 96, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 6, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 6, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 40, 2, 6, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 8, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 10, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 2, 10, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 64, 2, 10, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 24, 2, 6, 2048, 256, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 48, 2, 8, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 48, 4, 8, 2048, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 64, 4, 10, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 64, 4, 2, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 4, 2, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 64, 8, 4, 4096, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 7, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 16, 2, 8, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 4, 13, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 32, 8, 16, 2048, 256, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 6, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 6, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 14, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 18, 2, 10, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 14, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 14, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 9, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 6, 2, 11, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 15, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+
+    (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 30.0),
+    (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 1, 128, True, "BSND", False, -1, -1, 50.0),
+    (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 1, 128, False, "BSND", False, -1, -1, 50.0),
+    (torch.bfloat16, 4, 32, 32, 32, 2048, 128, 1, 128, False, "TND", False, -1, -1, 30.0),
+    (torch.bfloat16, 4, 32, 32, 48, 2048, 128, 1, 128, False, "TND", False, -1, -1, 50.0),
+    (torch.bfloat16, 4, 64, 64, 64, 2048, 128, 1, 128, False, "TND", False, -1, -1, 50.0),
 ]
 
 @pytest.mark.parametrize("num_splits", [0, 1, 2])
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, window_size_left, window_size_right", test_cases)
-def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, num_splits, window_size_left, window_size_right):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, num_splits, window_size_left, window_size_right, softcap):
     name = torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""
     if num_splits > 1 and not (cache_mode == 1 and layout == "TND"):
         pytest.skip("num_splits>1 requires paged KV cache and TND (varlen-q) layout")
@@ -274,10 +285,10 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         pytest.skip("Ascend950 does not support head_size>128")
     if is_varied and layout != "TND":
         pytest.skip("is_varied requires TND (varlen-q) layout")
-    q_min_range = -1.0
-    q_max_range = 1.0
-    kv_min_range = -1.0
-    kv_max_range = 1.0
+    q_min_range = -5.0
+    q_max_range = 5.0
+    kv_min_range = -5.0
+    kv_max_range = 5.0
     block_size = 128
     max_num_blocks_per_seq = (kv_seqlen + block_size - 1) // block_size
     num_blocks = max(64, max_num_blocks_per_seq * batch_size)
@@ -326,7 +337,6 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         kv_seqlen_list = kv_sequences
     scale = 1.0 / (head_size ** 0.5)
     is_rotary_interleaved = False
-    softcap = 0
     kv_seqlen_list = torch.tensor(kv_seqlen_list, dtype=torch.int32).npu()
     rotary_cos = None
     rotary_sin = None
@@ -386,7 +396,7 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         causal=is_causal,
         window_size=[window_size_left, window_size_right],
         attention_chunk=0,
-        softcap=0.0,
+        softcap=softcap,
         rotary_interleaved=is_rotary_interleaved,
         scheduler_metadata=None,
         num_splits=num_splits,
@@ -474,9 +484,9 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
                 key_cache_per_batch = torch.stack(keys, dim=0)
                 value_cache_per_batch = torch.stack(values, dim=0)
         if atten_mask is not None:
-            output, golden_lse = ref_flash_attention(query_cpu_per_batch, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu_per_batch, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu_per_batch, key_cache_per_batch, value_cache_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu_per_batch, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen_per_batch, num_heads, head_size)
         if is_local_golden:
             preTokens = window_size_left_golden
@@ -511,24 +521,26 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         torch.testing.assert_close(softmax_lse.cpu(), golden_lseL.cpu(), rtol=rtol, atol=atol)
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal)
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, True, False),
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap)
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 50.0)
 ]
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal", test_cases)
-def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
+def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):
     name = torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""
     if "Ascend910" not in name:
         pytest.skip("flash_attn_func only support Ascend910")
@@ -542,7 +554,6 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
     scale = 1.0 / (head_size ** 0.5)
     window_size_left = -1
     window_size_right = -1
-    softcap = 0.0
 
     ret = flash_attn_func(
         query,
@@ -568,9 +579,9 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
         value_cache_per_batch = value_cache.detach().cpu()[i]
         query_cpu = query.detach().cpu()[i]
         if is_causal:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen, num_heads, head_size)
         golden_out[i:i+1] = out
         golden_lseL[i:i+1] = golden_lse.reshape(num_heads, q_seqlen)
@@ -582,31 +593,36 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
 
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right)
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1),
-    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1),
-    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1),
-    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1),
-    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1),
-    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap)
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 0.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 0.0),
     # SWA
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128),
-    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256),
-    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0),
-    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0),
-    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0),
-    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128, 0.0),
+    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256, 0.0),
+    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0, 0.0),
+    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0, 0.0),
+    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0),
+    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0),
+    # Softcap
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 30.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 50.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 30.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 50.0),
 ]
 
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right", test_cases)
-def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap):
     name = torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""
     if "Ascend910" not in name:
         pytest.skip("flash_attn_varlen_func only support Ascend910")
@@ -623,8 +639,6 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     max_seqlen_q = q_seqlen
     max_seqlen_k = kv_seqlen
     scale = 1.0 / (head_size ** 0.5)
-    softcap = 0.0
-
     window_size_left_golden = window_size_left
     window_size_right_golden = window_size_right
     if kv_seqlen > 0 and window_size_left_golden >= kv_seqlen - 1:
@@ -676,9 +690,9 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         value_per_batch = value.detach().cpu()[(i - 1) * kv_seqlen : i * kv_seqlen]
         query_cpu = query.detach().cpu()[(i - 1) * q_seqlen : i * q_seqlen]
         if is_causal_golden or is_local_golden:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type, softcap)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type, softcap)
         out = output.reshape(q_seqlen, num_heads, head_size)
         if is_local_golden:
             preTokens = window_size_left_golden

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -162,7 +162,7 @@ test_cases = [
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
     # kv=4096 -> 8 S2 blocks: num_splits=2 -> 2 segs (4 blk each), num_splits=4 -> 4 segs (2 blk each).
-        (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
@@ -264,7 +264,7 @@ test_cases = [
     (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
-
+    # Softcap
     (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 30.0),
     (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 1, 128, True, "BSND", False, -1, -1, 50.0),
     (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 1, 128, False, "BSND", False, -1, -1, 50.0),
@@ -536,8 +536,11 @@ test_cases = [
     (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
     (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
     (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    # Softcap
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 50.0),
     (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 50.0)
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 50.0),
 ]
 @pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
 def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):


### PR DESCRIPTION
## Related Issue

Refs #65.


## Summary

Add support for **softcapping** in the **forward pass** of **arch22 v2/v3**.

- Implemented softcapping calculation in the online softmax epilogue.
- Added `HAS_SOFTCAP` template parameter.
- Reimplement `OperatePreMaskUb` function and remove redundant premask tensor.
- Move mask16 tensor from ub uint8 block 11 to 5.
- Updated forward test cases to verify softcapping functionality.


## Validation

Passed all forward softcap test cases for arch22 v2/v3.

<img width="1758" height="420" alt="image" src="https://github.com/user-attachments/assets/b2dd9402-3436-44e6-98b1-962dfb0c019d" />
<img width="1734" height="426" alt="image" src="https://github.com/user-attachments/assets/e3af89f9-7ff2-4f5e-8478-6792f758d912" />


## Additional Information

None.