### PR TITLE
fix aliasing failures in torch 2.10

### DIFF
--- a/csrc/arch35/flash_attn_npu_v3/mha_fwd.cpp
+++ b/csrc/arch35/flash_attn_npu_v3/mha_fwd.cpp
@@ -347,5 +347,6 @@ mha_fwd(at::Tensor q,
                 sync_err);
 
     at::Tensor empty_accum = at::empty({0}, at::device(at::kPrivateUse1).dtype(at::kFloat));
-    return {out, softmaxlse, empty_accum, empty_accum};
+    at::Tensor empty_softmax_lse_accum = at::empty({0}, at::device(at::kPrivateUse1).dtype(at::kFloat));
+    return {out, softmaxlse, empty_accum, empty_softmax_lse_accum};
 }


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->
Related to #54 


## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Fix issue that torch 2.10 tightened the custom-op output aliasing check against 950's same empty_accum returned twice.


## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->
<img width="1747" height="560" alt="image" src="https://github.com/user-attachments/assets/3ebb651b-e703-464b-bb24-a3881f19b877" />



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->