### PR TITLE
Feat: softcap bwd for arch22 v2/v3

### DIFF
--- a/csrc/arch22/flash_attn_npu_v2/fag_block.h
+++ b/csrc/arch22/flash_attn_npu_v2/fag_block.h
@@ -56,8 +56,10 @@ struct EpilogueAtlasA2FAGPre {
 };
 
 // For AtlasA2, MLAG Op
+template <bool HAS_SOFTCAP_>
 struct EpilogueAtlasA2FAGOp {
     using ArchTag = Arch::AtlasA2;
+    static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
 };
 
 // For AtlasA2, MLAG Sfmg
@@ -67,9 +69,11 @@ struct EpilogueAtlasA2FAGSfmg {
 };
 
 // For AtlasA2, MLAG Op
-template <uint32_t INPUT_LAYOUT_, bool IS_DROP_, bool IS_ATTEN_MASK_>
+template <uint32_t INPUT_LAYOUT_, bool IS_DROP_, bool IS_ATTEN_MASK_,
+bool HAS_SOFTCAP_>
 struct EpilogueAtlasA2SameAbVec {
     using ArchTag = Arch::AtlasA2;
+    static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
 };
 
 // For AtlasA2, MLAG Post

--- a/csrc/arch22/flash_attn_npu_v2/fag_epilogue_op.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_epilogue_op.hpp
@@ -38,22 +38,24 @@ template <
     uint32_t INPUT_LAYOUT_,
     uint32_t IS_DROP_,
     uint32_t IS_ATTEN_MASK_,
-    class TilingData
+    class TilingData,
+    bool HAS_SOFTCAP_
 >
 class BlockEpilogue<
-    EpilogueAtlasA2SameAbVec<INPUT_LAYOUT_, IS_DROP_, IS_ATTEN_MASK_>,
+    EpilogueAtlasA2SameAbVec<INPUT_LAYOUT_, IS_DROP_, IS_ATTEN_MASK_, HAS_SOFTCAP_>,
     OutputType_,
     InputType_,
     TilingData>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2SameAbVec<INPUT_LAYOUT_, IS_DROP_, IS_ATTEN_MASK_>;
+    using DispatchPolicy = EpilogueAtlasA2SameAbVec<INPUT_LAYOUT_, IS_DROP_, IS_ATTEN_MASK_, HAS_SOFTCAP_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
     using T1 = InputType_;
     using T2 = OutputType_;
     static constexpr uint32_t INPUT_LAYOUT = INPUT_LAYOUT_;
     static constexpr bool IS_DROP = IS_DROP_;
     static constexpr bool IS_ATTEN_MASK = IS_ATTEN_MASK_;
+    static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
 
     AscendC::TPipe *pipe;
     TBuf<> unifiedBuffer;
@@ -105,6 +107,7 @@ public:
 
     float keepProb;
     float scaleValue;
+    float softcapValue;
     int64_t s1Token;
     int64_t s2Token;
     int64_t actualCalcS1Token;
@@ -186,6 +189,7 @@ public:
     constexpr static uint32_t PREFIX_COMPRESS_CAUSAL_S_SIZE = 2048;
     constexpr static uint32_t PREFIX_COMPRESS_ALL_MASK_S1_SIZE = 1024;
     constexpr static int64_t GM_DOUBLE_BUFFER = 2;
+    constexpr static int64_t SOFTCAP_UB_OFFSET = 32 * 1024;
     constexpr static int64_t TMP_UB_OFFSET = 148 * 1024;
     constexpr static int64_t SFMG_UB_OFFSET = (148 + 33) * 1024;
     constexpr static int64_t TMP_UB_SIZE = 33 * 1024;
@@ -291,6 +295,7 @@ public:
         }
         keepProb = tilingData->keepProb;
         scaleValue = tilingData->scaleValue;
+        softcapValue = tilingData->softcapValue;
         compressMode = tilingData->attenMaskCompressMode;
 
         int64_t sfmgOutputSize = b * n2 * g * s1 * 8;
@@ -664,13 +669,33 @@ public:
 
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Muls(vecClc2Buffer, vecClc2Buffer, (T2)scaleValue, s1ExtendSubGraph * s2ExtendAlign);
+        AscendC::PipeBarrier<PIPE_V>();
 
+        // recompute softcap
+        if constexpr (HAS_SOFTCAP) {
+            AscendC::Maxs(vecClc2Buffer, vecClc2Buffer, -8.8f, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Muls(vecClc2Buffer, vecClc2Buffer, -2.0f, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(vecClc2Buffer, vecClc2Buffer, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, 1.0f, s1ExtendSubGraph * s2ExtendAlign);
+            // temp buffer for softcap
+            AscendC::LocalTensor<float> softcapBuffer = unifiedBuffer.GetWithOffset<float>(
+                cal_repeat_num, SOFTCAP_UB_OFFSET);
+            AscendC::Duplicate<float, false>(softcapBuffer, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Div<float, false>(vecClc2Buffer, softcapBuffer, vecClc2Buffer, (uint64_t)0, 
+                    (s1ExtendSubGraph*s2ExtendAlign)/64, {1, 1, 1, 8, 0, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, -softcapValue, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
         ///////////////////////////////////////////////////////////////
         // attenMask
         ///////////////////////////////////////////////////////////////
         if constexpr (IS_ATTEN_MASK == ENABLE) {
-            AscendC::PipeBarrier<PIPE_V>();
-
             // uint8_t
             if (AttenBandMode == AttenMaskCompress::All || AttenBandMode == AttenMaskCompress::NextOnly) {
                 CalcAttenMaskBool(vecClc2Buffer, attenMaskUbuint8, s1ExtendSubGraph, s2ExtendAlign);
@@ -688,9 +713,9 @@ public:
                 AscendC::WaitFlag<HardEvent::MTE2_V>(static_cast<int32_t>(vWaitMte2));
                 CalcAttenMaskBool(vecClc2Buffer, attenMaskUbuint8, s1ExtendSubGraph, s2ExtendAlign, 1);
             }
+            AscendC::PipeBarrier<PIPE_V>();
         }
 
-        AscendC::PipeBarrier<PIPE_V>();
         LocalTensor<float> simpleSoftmaxResBuf = unifiedBuffer.GetWithOffset<float>(33 * 1024 / sizeof(T2), DbBegin);
         CalcSoftMax(simpleSoftmaxResBuf, vecClc2Buffer, vecInBuffer3, s1ExtendSubGraph, s2Extend, s2ExtendAlign, softmaxTilingData);
         LocalTensor<T2> vecDropBuffer = simpleSoftmaxResBuf;
@@ -787,6 +812,15 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(mte2WaitMte3B);
         }
 
+        // Save S values before SubGrapA(i+1) MTE overwrites T2Begin
+        if constexpr (HAS_SOFTCAP) {
+            AscendC::LocalTensor<float> savedS = unifiedBuffer.GetWithOffset<float>(
+                32 * 1024 / sizeof(float), TMP_UB_OFFSET);
+            AscendC::LocalTensor<float> srcS = unifiedBuffer.GetWithOffset<float>(
+                32 * 1024 / sizeof(float), T2Begin);
+            AscendC::DataCopy(savedS, srcS, s1ExtendSubGraph * s2ExtendAlign);
+        }
+
         if (preS1Idx != curS1Idx) {
             preS1Idx = curS1Idx;
             LocalTensor<float> sfmgClc3 = unifiedBuffer.GetWithOffset<float>(SFMG_UB_SIZE / sizeof(float), SFMG_UB_OFFSET);
@@ -880,10 +914,29 @@ public:
         LocalTensor<float> simpleSoftmaxResBuf = unifiedBuffer.GetWithOffset<float>(32 * 1024 / sizeof(float), DbBegin);
 
         AscendC::Mul(vecClc1Buffer, vecClc1Buffer, simpleSoftmaxResBuf, s1ExtendSubGraph * s2ExtendAlign);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        if constexpr (HAS_SOFTCAP) {
+            // Use saved copy from TMP_UB_OFFSET (avoids race with SubGrapA MTE)
+            AscendC::LocalTensor<float> vecClc2Buffer =
+            unifiedBuffer.GetWithOffset<float>(32 * 1024 / sizeof(float), TMP_UB_OFFSET);
+            // avoid mask -INF
+            AscendC::Maxs(vecClc2Buffer, vecClc2Buffer, -softcapValue, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(vecClc2Buffer, vecClc2Buffer, vecClc2Buffer, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            // softcap * (1 - (S/softcap)^2) = softcap * sech^2(x)
+            AscendC::Muls(vecClc2Buffer, vecClc2Buffer, -(1.0f/softcapValue), s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, softcapValue, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(vecClc1Buffer, vecClc1Buffer, vecClc2Buffer, s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
         LocalTensor<T1> vecCopyOutBuffer = vecClc1Buffer.template ReinterpretCast<T1>();
         if constexpr (!AscendC::IsSameType<T1, float>::value) {
             vecCopyOutBuffer = unifiedBuffer.GetWithOffset<T1>(17 * 1024 / sizeof(T1), ubBufferOffset + T1Begin);
-            AscendC::PipeBarrier<PIPE_V>();
             AscendC::Cast(vecCopyOutBuffer, vecClc1Buffer, RoundMode::CAST_ROUND, s1ExtendSubGraph * s2ExtendAlign);
         }
 
@@ -985,16 +1038,18 @@ public:
 template <
     class ElementVecDtype,
     InputLayout inputLayout,
-    class TilingData>
+    class TilingData,
+    bool HAS_SOFTCAP_>
 class BlockEpilogue<
-    EpilogueAtlasA2FAGOp,
+    EpilogueAtlasA2FAGOp<HAS_SOFTCAP_>,
     ElementVecDtype,
     std::integral_constant<InputLayout, inputLayout>,
     TilingData>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2FAGOp;
+    using DispatchPolicy = EpilogueAtlasA2FAGOp<HAS_SOFTCAP_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
+    static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
 
     static constexpr InputLayout getLayout()
     {
@@ -1027,6 +1082,7 @@ public:
     constexpr static uint32_t T2BlockBegin = 66 * 1024;
 
     constexpr static uint32_t DbBegin = 74 * 1024;
+    constexpr static int64_t SOFTCAP_UB_OFFSET = 32 * 1024;
     constexpr static int64_t TMP_UB_OFFSET = 148 * 1024;
     constexpr static int64_t SFMG_UB_OFFSET = (148 + 33) * 1024;
     constexpr static int64_t TMP_UB_SIZE = 33 * 1024;
@@ -1054,6 +1110,7 @@ public:
     int64_t t1;
 
     float scaleValue;
+    float softcapValue;
 
     int32_t cubeBaseMN;
 
@@ -1119,6 +1176,7 @@ public:
         int64_t dsWorkSpaceOffset = tilingData->dsWorkSpaceOffset;
 
         scaleValue = tilingData->scaleValue;
+        softcapValue = tilingData->softcapValue;
         softmaxTilingData.srcM = tilingData->softmaxTilingData.srcM;
         softmaxTilingData.srcK = tilingData->softmaxTilingData.srcK;
         softmaxTilingData.srcSize = tilingData->softmaxTilingData.srcSize;
@@ -1288,19 +1346,40 @@ public:
 
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Muls(vecClc2Buffer, vecClc2Buffer, scaleValue, s1Extend * s2ExtendAlign);
-
         AscendC::PipeBarrier<PIPE_V>();
+
+        // recompute softcap
+        if constexpr (HAS_SOFTCAP) {
+            AscendC::Maxs(vecClc2Buffer, vecClc2Buffer, -8.8f, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Muls(vecClc2Buffer, vecClc2Buffer, -2.0f, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(vecClc2Buffer, vecClc2Buffer, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, 1.0f, s1Extend * s2ExtendAlign);
+
+            AscendC::LocalTensor<float> softcapBuffer = unifiedBuffer.GetWithOffset<float>(
+                cal_repeat_num, SOFTCAP_UB_OFFSET);
+            AscendC::Duplicate<float, false>(softcapBuffer, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Div<float, false>(vecClc2Buffer, softcapBuffer, vecClc2Buffer, (uint64_t)0, s1Extend*s2ExtendAlign/64, {1, 1, 1, 8, 0, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, -softcapValue, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
         LocalTensor<uint8_t> attenMaskUbuint8 =
             unifiedBuffer.GetWithOffset<uint8_t>(16 * 1024 / sizeof(uint8_t), ubBufferOffset + BoolBegin);
         if (blockInfo.SeqQIdx == blockInfo.SeqKIdx) {
             CalcAttenMaskBool(vecClc2Buffer, attenMaskUbuint8[curSeqQIdx * s1VecSize * 128], s1Extend, s2ExtendAlign,
                 S2_CUBESIZE, 0);
+            AscendC::PipeBarrier<PIPE_V>();
         }
 
         ///////////////////////////////////////////////////////////////
         // simpleSoftMax
         ///////////////////////////////////////////////////////////////
-        AscendC::PipeBarrier<PIPE_V>();
         LocalTensor<float> simpleSoftmaxResBuf = unifiedBuffer.GetWithOffset<float>(33 * 1024 / sizeof(float), DbBegin);
         CalcSoftMax(simpleSoftmaxResBuf, vecClc2Buffer, vecInBuffer3, s1Extend, s2Extend, s2ExtendAlign,
             softmaxTilingData);
@@ -1332,6 +1411,15 @@ public:
 
         if (curIdx > 0) {
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(mte2WaitMte3B);
+        }
+
+        // Save S values before SubGrapA(i+1) MTE overwrites T2Begin
+        if constexpr (HAS_SOFTCAP) {
+            LocalTensor<float> savedS = unifiedBuffer.GetWithOffset<float>(
+                32 * 1024 / sizeof(float), TMP_UB_OFFSET);
+            LocalTensor<float> srcS = unifiedBuffer.GetWithOffset<float>(
+                32 * 1024 / sizeof(float), T2Begin);
+            AscendC::DataCopy(savedS, srcS, s1Extend * s2ExtendAlign);
         }
 
         // copyIn sfmg
@@ -1368,8 +1456,25 @@ public:
         AscendC::PipeBarrier<PIPE_V>();
         LocalTensor<float> simpleSoftmaxResBuf = unifiedBuffer.GetWithOffset<float>(32 * 1024 / sizeof(float), DbBegin);
         Mul(vecClc1Buffer, vecClc1Buffer, simpleSoftmaxResBuf, s1Extend * s2ExtendAlign);
-
         AscendC::PipeBarrier<PIPE_V>();
+
+        if constexpr (HAS_SOFTCAP) {
+            // Use saved copy from TMP_UB_OFFSET (avoids race with SubGrapA MTE)
+            AscendC::LocalTensor<float> vecClc2Buffer =
+            unifiedBuffer.GetWithOffset<float>(32 * 1024 / sizeof(float), TMP_UB_OFFSET);
+            AscendC::Maxs(vecClc2Buffer, vecClc2Buffer, -softcapValue, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(vecClc2Buffer, vecClc2Buffer, vecClc2Buffer, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            // softcap * (1 - (S/softcap)^2) = softcap * sech^2(x)
+            AscendC::Muls(vecClc2Buffer, vecClc2Buffer, -(1.0f/softcapValue), s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(vecClc2Buffer, vecClc2Buffer, softcapValue, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(vecClc1Buffer, vecClc1Buffer, vecClc2Buffer, s1Extend * s2ExtendAlign);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
         LocalTensor<ElementVecDtype> vecCopyOutBuffer = unifiedBuffer.GetWithOffset<ElementVecDtype>(17 * 1024 /
             sizeof(ElementVecDtype), ubBufferOffset + T1Begin);
         Cast(vecCopyOutBuffer, vecClc1Buffer, RoundMode::CAST_ROUND, s1Extend * s2ExtendAlign);

--- a/csrc/arch22/flash_attn_npu_v2/fag_general_dispatch.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_general_dispatch.hpp
@@ -32,7 +32,8 @@ struct FagGeneralLaunchArgs {
     uint64_t fftsAddr;
     bool is_causal;
     bool deterministic;
-    uint32_t qk_headdim_kernel;   // 64 / 128 / 192 / 256
+    bool is_softcap;
+    uint32_t qk_headdim_kernel; // 64 / 128 / 192 / 256
     uint8_t *dOutDevice;
     uint8_t *qDevice;
     uint8_t *kDevice;

--- a/csrc/arch22/flash_attn_npu_v2/fag_general_dispatch_impl.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_general_dispatch_impl.hpp
@@ -58,12 +58,12 @@
 // Launch one FAGGeneral specialization. IS_CAUSAL / IS_DTM map to the kernel's
 // IS_ATTEN_MASK / IS_DTM template params; ALN selects DTemplateType::AlignedNNN.
 // Argument order is identical to LaunchFAGGeneralKernel in fag_general_launch.hpp.
-#define GEN_LAUNCH(ALN, IS_CAUSAL, IS_DTM)                                       \
-    ::FAGGeneral<DTemplateType::ALN, DType, kInputLayout, IS_CAUSAL, 0, IS_DTM>  \
-        <<<a.blockDim, nullptr, a.aclStream>>>(                                  \
-            a.fftsAddr, a.dOutDevice, a.qDevice, a.kDevice, a.vDevice,           \
-            a.outDevice, nullptr, a.attenMaskDevice, a.softMaxLseDevice,         \
-            a.cuSeqQlenDevice, a.cuSeqKvlenDevice, a.dqDevice, a.dkDevice,       \
+#define GEN_LAUNCH(ALN, IS_CAUSAL, IS_DTM, IS_SOFTCAP)                                       \
+    ::FAGGeneral<DTemplateType::ALN, DType, kInputLayout, IS_CAUSAL, 0, IS_DTM, IS_SOFTCAP>  \
+        <<<a.blockDim, nullptr, a.aclStream>>>(                                              \
+            a.fftsAddr, a.dOutDevice, a.qDevice, a.kDevice, a.vDevice,                       \
+            a.outDevice, nullptr, a.attenMaskDevice, a.softMaxLseDevice,                     \
+            a.cuSeqQlenDevice, a.cuSeqKvlenDevice, a.dqDevice, a.dkDevice,                   \
             a.dvDevice, nullptr, a.workspaceDevice, a.tilingDevice)
 
 template <typename DType, uint32_t kInputLayout>
@@ -72,43 +72,84 @@ void launch_fag_general_dispatch_impl(const FagGeneralLaunchArgs &a) {
     // fag_general_launch.hpp (RunOpApiV2("ascendc_fag", ...)).
     auto fag_general_call = [=]() -> int {
         const uint32_t hd = a.qk_headdim_kernel;
-        if (a.is_causal) {
-            if (a.deterministic) {
-                switch (hd) {
-                    case 64:  GEN_LAUNCH(Aligned64,  1, 1); break;
-                    case 128: GEN_LAUNCH(Aligned128, 1, 1); break;
-                    case 192: GEN_LAUNCH(Aligned192, 1, 1); break;
-                    case 256: GEN_LAUNCH(Aligned256, 1, 1); break;
-                    default: break;
+        if (a.is_softcap) {
+            if (a.is_causal) {
+                if (a.deterministic) {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  1, 1, 1); break;
+                        case 128: GEN_LAUNCH(Aligned128, 1, 1, 1); break;
+                        case 192: GEN_LAUNCH(Aligned192, 1, 1, 1); break;
+                        case 256: GEN_LAUNCH(Aligned256, 1, 1, 1); break;
+                        default: break;
+                    }
+                } else {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  1, 0, 1); break;
+                        case 128: GEN_LAUNCH(Aligned128, 1, 0, 1); break;
+                        case 192: GEN_LAUNCH(Aligned192, 1, 0, 1); break;
+                        case 256: GEN_LAUNCH(Aligned256, 1, 0, 1); break;
+                        default: break;
+                    }
                 }
             } else {
-                switch (hd) {
-                    case 64:  GEN_LAUNCH(Aligned64,  1, 0); break;
-                    case 128: GEN_LAUNCH(Aligned128, 1, 0); break;
-                    case 192: GEN_LAUNCH(Aligned192, 1, 0); break;
-                    case 256: GEN_LAUNCH(Aligned256, 1, 0); break;
-                    default: break;
+                if (a.deterministic) {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  0, 1, 1); break;
+                        case 128: GEN_LAUNCH(Aligned128, 0, 1, 1); break;
+                        case 192: GEN_LAUNCH(Aligned192, 0, 1, 1); break;
+                        case 256: GEN_LAUNCH(Aligned256, 0, 1, 1); break;
+                        default: break;
+                    }
+                } else {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  0, 0, 1); break;
+                        case 128: GEN_LAUNCH(Aligned128, 0, 0, 1); break;
+                        case 192: GEN_LAUNCH(Aligned192, 0, 0, 1); break;
+                        case 256: GEN_LAUNCH(Aligned256, 0, 0, 1); break;
+                        default: break;
+                    }
                 }
             }
         } else {
-            if (a.deterministic) {
-                switch (hd) {
-                    case 64:  GEN_LAUNCH(Aligned64,  0, 1); break;
-                    case 128: GEN_LAUNCH(Aligned128, 0, 1); break;
-                    case 192: GEN_LAUNCH(Aligned192, 0, 1); break;
-                    case 256: GEN_LAUNCH(Aligned256, 0, 1); break;
-                    default: break;
+            if (a.is_causal) {
+                if (a.deterministic) {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  1, 1, 0); break;
+                        case 128: GEN_LAUNCH(Aligned128, 1, 1, 0); break;
+                        case 192: GEN_LAUNCH(Aligned192, 1, 1, 0); break;
+                        case 256: GEN_LAUNCH(Aligned256, 1, 1, 0); break;
+                        default: break;
+                    }
+                } else {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  1, 0, 0); break;
+                        case 128: GEN_LAUNCH(Aligned128, 1, 0, 0); break;
+                        case 192: GEN_LAUNCH(Aligned192, 1, 0, 0); break;
+                        case 256: GEN_LAUNCH(Aligned256, 1, 0, 0); break;
+                        default: break;
+                    }
                 }
             } else {
-                switch (hd) {
-                    case 64:  GEN_LAUNCH(Aligned64,  0, 0); break;
-                    case 128: GEN_LAUNCH(Aligned128, 0, 0); break;
-                    case 192: GEN_LAUNCH(Aligned192, 0, 0); break;
-                    case 256: GEN_LAUNCH(Aligned256, 0, 0); break;
-                    default: break;
+                if (a.deterministic) {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  0, 1, 0); break;
+                        case 128: GEN_LAUNCH(Aligned128, 0, 1, 0); break;
+                        case 192: GEN_LAUNCH(Aligned192, 0, 1, 0); break;
+                        case 256: GEN_LAUNCH(Aligned256, 0, 1, 0); break;
+                        default: break;
+                    }
+                } else {
+                    switch (hd) {
+                        case 64:  GEN_LAUNCH(Aligned64,  0, 0, 0); break;
+                        case 128: GEN_LAUNCH(Aligned128, 0, 0, 0); break;
+                        case 192: GEN_LAUNCH(Aligned192, 0, 0, 0); break;
+                        case 256: GEN_LAUNCH(Aligned256, 0, 0, 0); break;
+                        default: break;
+                    }
                 }
             }
-        }
+        } 
+        
         return 0;
     };
     at_npu::native::OpCommand::RunOpApiV2("ascendc_fag", fag_general_call);

--- a/csrc/arch22/flash_attn_npu_v2/fag_general_host.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_general_host.cpp
@@ -30,6 +30,7 @@ std::vector<at::Tensor> launch_fag_general(
     int64_t max_seqlen_q,
     int64_t max_seqlen_k,
     float softmax_scale,
+    float softcap,
     bool is_causal,
     int64_t window_size_left,
     int64_t window_size_right,
@@ -67,7 +68,15 @@ std::vector<at::Tensor> launch_fag_general(
     uint32_t tilingSize = sizeof(FAGTilingData);
     at::Tensor tiling_cpu_tensor = at::empty({static_cast<long>(tilingSize)}, at::device(c10::kCPU).dtype(at::kByte));
     FAGTiling::FAGInfo fagInfo;
-    fagInfo.scaleValue = softmax_scale;
+    
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
+        fagInfo.scaleValue = softmax_scale / softcap;
+    } else {
+        fagInfo.scaleValue = softmax_scale;
+    }
+    fagInfo.softcapValue = softcap;
+
     fagInfo.keepProb = 1.0f;
     if (window_size_left >= max_seqlen_k - 1) {
         window_size_left = -1;
@@ -195,6 +204,7 @@ std::vector<at::Tensor> launch_fag_general(
     gen_args.aclStream = aclStream;
     gen_args.fftsAddr = fftsAddr;
     gen_args.is_causal = has_attn_mask;
+    gen_args.is_softcap = has_softcap;
     gen_args.deterministic = deterministic;
     gen_args.qk_headdim_kernel = qk_headdim_kernel;
     gen_args.dOutDevice = dOutDevice;

--- a/csrc/arch22/flash_attn_npu_v2/fag_general_host.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_general_host.hpp
@@ -23,6 +23,7 @@ std::vector<at::Tensor> launch_fag_general(
     int64_t max_seqlen_q,
     int64_t max_seqlen_k,
     float softmax_scale,
+    float softcap,
     bool is_causal,
     int64_t window_size_left,
     int64_t window_size_right,

--- a/csrc/arch22/flash_attn_npu_v2/fag_tiling.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/fag_tiling.cpp
@@ -18,6 +18,7 @@
 namespace FAGTiling {
 struct FAGInfo {
     float scaleValue;
+    float softcapValue;
 
     int64_t seqQShapeSize;
     int64_t queryShape_0;
@@ -67,6 +68,7 @@ int32_t GetFATilingParam(const FAGInfo fagInfo, uint32_t &blockDim, int64_t *til
     uint32_t coreNum = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAic();
     uint32_t vectorCoreNum = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAiv();
     fagV2TilingData->coreNum = vectorCoreNum;
+    fagV2TilingData->softcapValue = fagInfo.softcapValue;
     fagV2TilingData->scaleValue = fagInfo.scaleValue;
     fagV2TilingData->batch = fagInfo.seqQShapeSize;
     fagV2TilingData->t1 = fagInfo.queryShape_0;

--- a/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/flash_api.cpp
@@ -1114,6 +1114,8 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         dv = torch::empty_like(v);
     }
 
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
+
     // parse shape args
     auto qsizes = q.sizes();
     auto ksizes = k.sizes();
@@ -1141,7 +1143,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
             dout, q, k, v, out, softmax_lse, dq, dk, dv,
             seqlens_q, seqlens_k,
             max_seqlen_q, max_seqlen_k,
-            scale, local_is_causal, local_window_size_left, local_window_size_right, deterministic);
+            scale, softcap, local_is_causal, local_window_size_left, local_window_size_right, deterministic);
     }
 
     // tiling args set
@@ -1155,7 +1157,13 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     fagInfo.queryShape_1 = nheads;
     fagInfo.keyShape_1 = nheads_k;
     fagInfo.queryShape_2 = headdim;
-    fagInfo.scaleValue = 1.0 / sqrt(headdim);
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
+        fagInfo.scaleValue = softmax_scale / softcap;
+    } else {
+        fagInfo.scaleValue = softmax_scale;
+    }
+    fagInfo.softcapValue = softcap;
     uint64_t workspaceSize = 0;
     FAGTiling::GetFATilingParam(fagInfo, blockDim, reinterpret_cast<int64_t *>(tiling_cpu_tensor.data_ptr<uint8_t>()), workspaceSize);
     at::Tensor tiling_gpu_tensor = tiling_cpu_tensor.to(at::Device(at::kPrivateUse1));
@@ -1213,6 +1221,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     vb_args.fftsAddr = fftsAddr;
     vb_args.is_bf16 = is_bf16;
     vb_args.is_causal = is_causal;
+    vb_args.is_softcap = has_softcap;
     vb_args.qDevice = qDevice;
     vb_args.kDevice = kDevice;
     vb_args.vDevice = vDevice;
@@ -1276,6 +1285,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         dv = torch::empty_like(v);
     }
 
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
+
     auto qsizes = q.sizes();
     auto ksizes = k.sizes();
     float scale = softmax_scale > 0.f ? softmax_scale
@@ -1284,7 +1295,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         dout, q, k, v, out, softmax_lse, dq, dk, dv,
         std::nullopt, std::nullopt,
         qsizes[1], ksizes[1],
-        scale, is_causal, window_size_left, window_size_right, deterministic);
+        scale, softcap, is_causal, window_size_left, window_size_right, deterministic);
 }
 
 PYBIND11_MODULE(flash_attn_npu_arch22_v2, m)

--- a/csrc/arch22/flash_attn_npu_v2/kernel_common_fag.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/kernel_common_fag.hpp
@@ -38,6 +38,7 @@ struct FAGTilingData {
     uint32_t attenMaskCompressMode = 0;
     uint32_t layoutType;
     float scaleValue;
+    float softcapValue;
     float keepProb;
 
     uint32_t dataTypeSize;
@@ -94,6 +95,7 @@ struct FAGv2TilingData {
     int64_t dsWorkSpaceOffset;
     uint32_t coreNum;
     float scaleValue;
+    float softcapValue;
     int64_t batch;
     int64_t t1;
     int64_t t2;

--- a/csrc/arch22/flash_attn_npu_v2/mha_varlen_bwd.cpp
+++ b/csrc/arch22/flash_attn_npu_v2/mha_varlen_bwd.cpp
@@ -347,7 +347,8 @@ private:
 template <
     typename InputDtype = half,
     MaskType maskType = MaskType::NO_MASK,
-    InputLayout inputLayout = InputLayout::TND>
+    InputLayout inputLayout = InputLayout::TND,
+    bool HAS_SOFTCAP = false>
 __global__ __aicore__
 void FAGVarlenOpt(uint64_t fftsAddr,
         GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR dout,
@@ -431,7 +432,7 @@ void FAGVarlenOpt(uint64_t fftsAddr,
     using EpilogueFAGSfmg = Catlass::Epilogue::Block::BlockEpilogue<EpilogueAtlasA2FAGSfmg, ElementVecDtype, FAGv2TilingData>;
 
     // VEC_Op：计算S = Mask(Q*K^T)，并完成重计算 P = Softmax(S)，再计算dS = P * Sub(dP, Sfmg)
-    using EpilogueAtlasA2FAGOp = Catlass::Epilogue::EpilogueAtlasA2FAGOp;
+    using EpilogueAtlasA2FAGOp = Catlass::Epilogue::EpilogueAtlasA2FAGOp<HAS_SOFTCAP>;
     using EpilogueFAGOp = Catlass::Epilogue::Block::BlockEpilogue<EpilogueAtlasA2FAGOp, ElementVecDtype, std::integral_constant<InputLayout, inputLayout>, FAGv2TilingData>;
 
     // VEC_Post：dQ*scale和dK*scale，并搬运输出dQ/dK/dV

--- a/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/online_softmax.hpp
@@ -74,18 +74,16 @@ public:
         constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
-
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
-
-        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
@@ -94,6 +92,7 @@ public:
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
@@ -101,8 +100,6 @@ public:
         llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
-        tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
-        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -408,27 +405,15 @@ public:
 
     __aicore__ inline void OperatePreMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
     {
-        UpCastMask<half, ElementMask>(
-            maskUbTensor16,
-            maskUbTensor,
-            rowNumCurLoop,
-            columnNumRound
-        );
-        AscendC::CompareScalar(
-            maskUbTensor,
-            maskUbTensor16,
-            static_cast<half>(1.0),
-            AscendC::CMPMODE::NE,
-            REPEAT_SIZE_IN_BYTE / sizeof(half),
-            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
-            AscendC::UnaryRepeatParams(1, 1, 8, 8)
-        );
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
+        UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+        // 0 -> 1, 1 -> 0
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+        AscendC::Adds<float, false>(maskUbTensor32, maskUbTensor32, -1.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Abs<float, false>(maskUbTensor32, maskUbTensor32, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
     }
 
     __aicore__ inline void OperateNextMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
@@ -525,11 +510,11 @@ public:
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
 
-        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Div<float, false>(
             lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
-            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 0, 8));
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
@@ -1076,7 +1061,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
                 UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
                 UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
-                
+
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 if constexpr (HAS_SOFTCAP_) {
@@ -1256,8 +1241,9 @@ public:
                 uint32_t rowNumCurLoop =
                     (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
 
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);    
                 if (doTriUPreMask && doTriUNextMask) {
+                    // *** TriUPreMask
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
@@ -1267,26 +1253,25 @@ public:
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                    if (doTriUNextMask) {
-                        uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
-                        // the token num of the prologue part
-                        uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
-                                               tokenNumPerHeadThisSubBlock;
-                        // the token num of the epilogue part
-                        uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
-                        // the number of integral heads within a cycle
-                        uint32_t epiTokenNum =
-                            rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                        CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
-                                       tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
-                                       epiTokenNum, true);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        OperateNextMaskUb(rowNumCurLoop, columnNumRound);
-                        ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
-                                  addMaskUbOffset);
-                    }
+                    // *** TriUNextMask
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
+                                            tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum =
+                        rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                    CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
+                                    tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
+                                    epiTokenNum, true);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                    ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
+                                addMaskUbOffset);
                 } else if (doTriUPreMask) {
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
@@ -1372,7 +1357,6 @@ private:
     AscendC::LocalTensor<float> dmUbTensor;
     AscendC::LocalTensor<float> llUbTensor;
     AscendC::LocalTensor<float> tvUbTensor;
-    AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
     AscendC::LocalTensor<float> softcapUbTensor;
 };

--- a/csrc/arch22/flash_attn_npu_v2/rescale_o.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/rescale_o.hpp
@@ -86,8 +86,8 @@ public:
         // Allocate UB space
         constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
 
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
@@ -102,7 +102,7 @@ public:
         goUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(GO_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
-        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
+        lseUbTensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
     }
 
     __aicore__ inline
@@ -141,7 +141,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -157,7 +157,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -519,15 +519,15 @@ public:
                 if (isLastRowLoop) {
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Ln<float, false>(
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
                         glUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Add<float, false>(
-                        lse32_ubuf_tensor,
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
+                        lseUbTensor,
                         gmUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -536,7 +536,7 @@ public:
                     // *** lse_block = expand_to_block(lse)
                     AscendC::Brcb(
                         tvUbTensor.ReinterpretCast<uint32_t>(),
-                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        lseUbTensor.ReinterpretCast<uint32_t>(),
                         CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                         AscendC::BrcbRepeatParams(1, 8));
                     InvalidLineLSEProcess(qNThisSubBlock, delStartRow, qSBlockIdx,
@@ -567,7 +567,7 @@ public:
                         if (qNThisSubBlock == 0U) {
                             // single head: its tokens are contiguous in BNS/NT -> plain lse32 burst.
                             AscendC::DataCopyPad(
-                                gLse, lse32_ubuf_tensor,
+                                gLse, lseUbTensor,
                                 AscendC::DataCopyExtParams(1, totalRowNum * sizeof(float), 0, 0, 0));
                         } else {
                             // multi-head: per-token gather (srcStride) + scatter (dstStride).
@@ -592,15 +592,15 @@ public:
                     if (isLastRowLoop) {
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Ln<float, false>(
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
                             glUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Add<float, false>(
-                            lse32_ubuf_tensor,
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
+                            lseUbTensor,
                             gmUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -608,7 +608,7 @@ public:
 
                         AscendC::Brcb(
                             tvUbTensor.ReinterpretCast<uint32_t>(),
-                            lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                            lseUbTensor.ReinterpretCast<uint32_t>(),
                             CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                             AscendC::BrcbRepeatParams(1, 8));
                         AscendC::PipeBarrier<PIPE_V>();
@@ -801,7 +801,7 @@ private:
     AscendC::LocalTensor<ElementOutput> goUbTensor16;
     AscendC::LocalTensor<float> goUbTensor32;
     AscendC::LocalTensor<float> gmUbTensor;
-    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+    AscendC::LocalTensor<float> lseUbTensor;
 };
 
 }

--- a/csrc/arch22/flash_attn_npu_v2/varlen_bwd_dispatch.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/varlen_bwd_dispatch.hpp
@@ -22,6 +22,7 @@ struct VarlenBwdLaunchArgs {
     uint64_t fftsAddr;
     bool is_bf16;
     bool is_causal;
+    bool is_softcap;
     uint8_t *qDevice;
     uint8_t *kDevice;
     uint8_t *vDevice;

--- a/csrc/arch22/flash_attn_npu_v2/varlen_bwd_dispatch_impl.hpp
+++ b/csrc/arch22/flash_attn_npu_v2/varlen_bwd_dispatch_impl.hpp
@@ -42,6 +42,7 @@ void launch_varlen_bwd_impl(const VarlenBwdLaunchArgs &a) {
         const aclrtStream aclStream = a.aclStream;
         const uint64_t fftsAddr = a.fftsAddr;
         const bool is_causal = a.is_causal;
+        const bool is_softcap = a.is_softcap;
         uint8_t *qDevice = a.qDevice;
         uint8_t *kDevice = a.kDevice;
         uint8_t *vDevice = a.vDevice;
@@ -67,18 +68,34 @@ void launch_varlen_bwd_impl(const VarlenBwdLaunchArgs &a) {
         aclCheck(aclrtSynchronizeStream(aclStream));
         Adx::AdumpPrintWorkSpace(ptrDumpDevice, ALL_DUMPSIZE, aclStream, "device_fag");
         aclCheck(aclrtFree(ptrDumpDevice));
-#else
-        if (is_causal) {
-            FAG::FAGVarlenOpt<DType, MaskType::MASK_CAUSAL, InputLayout::TND><<<blockDim, nullptr, aclStream>>>(
-                fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
-                attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
-                nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
-        } else {
-            FAG::FAGVarlenOpt<DType, MaskType::NO_MASK, InputLayout::TND><<<blockDim, nullptr, aclStream>>>(
-                fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
-                attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
-                nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
+#else      
+        if (is_softcap) {
+            if (is_causal) {
+                FAG::FAGVarlenOpt<DType, MaskType::MASK_CAUSAL, InputLayout::TND, true><<<blockDim, nullptr, aclStream>>>(
+                    fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
+                    attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
+                    nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
+            } else {
+                FAG::FAGVarlenOpt<DType, MaskType::NO_MASK, InputLayout::TND, true><<<blockDim, nullptr, aclStream>>>(
+                    fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
+                    attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
+                    nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
+            }
         }
+        else {
+            if (is_causal) {
+                FAG::FAGVarlenOpt<DType, MaskType::MASK_CAUSAL, InputLayout::TND, false><<<blockDim, nullptr, aclStream>>>(
+                    fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
+                    attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
+                    nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
+            } else {
+                FAG::FAGVarlenOpt<DType, MaskType::NO_MASK, InputLayout::TND, false><<<blockDim, nullptr, aclStream>>>(
+                    fftsAddr, qDevice, kDevice, vDevice, dOutDevice, nullptr, nullptr, nullptr, nullptr, nullptr,
+                    attenMaskDevice, softMaxLseDevice, nullptr, outDevice, nullptr, cuSeqQlenDevice, cuSeqKvlenDevice,
+                    nullptr, nullptr, dqDevice, dkDevice, dvDevice, workspaceDevice, tilingDevice, nullptr);
+            }
+        }
+        
 #endif
         return 0;
     };

--- a/csrc/arch22/flash_attn_npu_v3/bwd_dispatch.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/bwd_dispatch.hpp
@@ -30,6 +30,7 @@ struct BwdLaunchArgs {
     aclrtStream aclStream;
     uint64_t fftsAddr;
     bool is_bf16;
+    bool is_softcap;
     bool has_attn_mask;
     bool deterministic;
     uint32_t qk_headdim_kernel;  // 64 / 128 / 192 / 256

--- a/csrc/arch22/flash_attn_npu_v3/bwd_dispatch_common.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/bwd_dispatch_common.hpp
@@ -46,35 +46,35 @@
 // All 17 FAGGeneral launch arguments are identical across every instantiation;
 // only the template parameters differ. Collapse the boilerplate into a macro so
 // the call sites cannot drift from each other.
-#define BWD_LAUNCH(DT, DTYPE, IS_MASK, IS_DTM)                                       \
-    do {                                                                             \
-        FAGGeneral<DT, DTYPE, kInputLayout, IS_MASK, 0, IS_DTM>                      \
-            <<<blockDim, nullptr, aclStream>>>(                                      \
-                fftsAddr, dOutDevice, qDevice, kDevice, vDevice, outDevice,          \
-                nullptr, attenMaskDevice, softMaxLseDevice,                          \
-                cuSeqQlenDevice, cuSeqKvlenDevice,                                   \
-                dqDevice, dkDevice, dvDevice, nullptr, workspaceDevice, tilingDevice); \
+#define BWD_LAUNCH(DT, DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP)                                       \
+    do {                                                                                         \
+        FAGGeneral<DT, DTYPE, kInputLayout, IS_MASK, 0, IS_DTM, IS_SOFTCAP>                      \
+            <<<blockDim, nullptr, aclStream>>>(                                                  \
+                fftsAddr, dOutDevice, qDevice, kDevice, vDevice, outDevice,                      \
+                nullptr, attenMaskDevice, softMaxLseDevice,                                      \
+                cuSeqQlenDevice, cuSeqKvlenDevice,                                               \
+                dqDevice, dkDevice, dvDevice, nullptr, workspaceDevice, tilingDevice);           \
     } while (0)
 
 // Pick the headdim specialization at runtime.
-#define BWD_LAUNCH_HD(DTYPE, IS_MASK, IS_DTM)              \
-    do {                                                    \
-        switch (qk_headdim_kernel) {                        \
-            case 64:                                        \
-                BWD_LAUNCH(DTemplateType::Aligned64, DTYPE, IS_MASK, IS_DTM);  \
-                break;                                      \
-            case 128:                                       \
-                BWD_LAUNCH(DTemplateType::Aligned128, DTYPE, IS_MASK, IS_DTM); \
-                break;                                      \
-            case 192:                                       \
-                BWD_LAUNCH(DTemplateType::Aligned192, DTYPE, IS_MASK, IS_DTM); \
-                break;                                      \
-            case 256:                                       \
-                BWD_LAUNCH(DTemplateType::Aligned256, DTYPE, IS_MASK, IS_DTM); \
-                break;                                      \
-            default:                                        \
-                break;                                      \
-        }                                                   \
+#define BWD_LAUNCH_HD(DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP)                                  \
+    do {                                                                                   \
+        switch (qk_headdim_kernel) {                                                       \
+            case 64:                                                                       \
+                BWD_LAUNCH(DTemplateType::Aligned64, DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP);  \
+                break;                                                                     \
+            case 128:                                                                      \
+                BWD_LAUNCH(DTemplateType::Aligned128, DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP); \
+                break;                                                                     \
+            case 192:                                                                      \
+                BWD_LAUNCH(DTemplateType::Aligned192, DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP); \
+                break;                                                                     \
+            case 256:                                                                      \
+                BWD_LAUNCH(DTemplateType::Aligned256, DTYPE, IS_MASK, IS_DTM, IS_SOFTCAP); \
+                break;                                                                     \
+            default:                                                                       \
+                break;                                                                     \
+        }                                                                                  \
     } while (0)
 
 // Bind the BwdLaunchArgs fields to the names the launch macros expect, then run
@@ -87,6 +87,7 @@ void bwd_dispatch_run(const BwdLaunchArgs &a) {
     const uint32_t blockDim = a.blockDim;
     const aclrtStream aclStream = a.aclStream;
     const uint64_t fftsAddr = a.fftsAddr;
+    const bool is_softcap = a.is_softcap;
     const bool has_attn_mask = a.has_attn_mask;
     const bool deterministic = a.deterministic;
     const uint32_t qk_headdim_kernel = a.qk_headdim_kernel;
@@ -105,22 +106,39 @@ void bwd_dispatch_run(const BwdLaunchArgs &a) {
     uint8_t *workspaceDevice = a.workspaceDevice;
     uint8_t *tilingDevice = a.tilingDevice;
     (void)blockDim; (void)aclStream; (void)fftsAddr; (void)has_attn_mask;
-    (void)deterministic; (void)qk_headdim_kernel;
+    (void)deterministic; (void)is_softcap; (void)qk_headdim_kernel;
 
     auto launch_fag_general_kernel = [=]() -> int {
-        if (has_attn_mask) {
-            if (deterministic) {
-                BWD_LAUNCH_HD(DType, 1, 1);
+        if (is_softcap) {
+            if (has_attn_mask) {
+                if (deterministic) {
+                    BWD_LAUNCH_HD(DType, 1, 1, 1);
+                } else {
+                    BWD_LAUNCH_HD(DType, 1, 0, 1);
+                }
             } else {
-                BWD_LAUNCH_HD(DType, 1, 0);
+                if (deterministic) {
+                    BWD_LAUNCH_HD(DType, 0, 1, 1);
+                } else {
+                    BWD_LAUNCH_HD(DType, 0, 0, 1);
+                }
             }
         } else {
-            if (deterministic) {
-                BWD_LAUNCH_HD(DType, 0, 1);
+            if (has_attn_mask) {
+                if (deterministic) {
+                    BWD_LAUNCH_HD(DType, 1, 1, 0);
+                } else {
+                    BWD_LAUNCH_HD(DType, 1, 0, 0);
+                }
             } else {
-                BWD_LAUNCH_HD(DType, 0, 0);
+                if (deterministic) {
+                    BWD_LAUNCH_HD(DType, 0, 1, 0);
+                } else {
+                    BWD_LAUNCH_HD(DType, 0, 0, 0);
+                }
             }
         }
+        
         return 0;
     };
     at_npu::native::OpCommand::RunOpApiV2("ascendc_fag_general", launch_fag_general_kernel);

--- a/csrc/arch22/flash_attn_npu_v3/fag_kernel.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/fag_kernel.cpp
@@ -986,7 +986,8 @@ struct TypeSelector<DTemplateType::Aligned256> {
 template <const DTemplateType DTEMPLATETYPE, typename DataType = half,
           const uint32_t INPUT_LAYOUT = BSND, const bool IS_ATTEN_MASK = 0,
           const bool IS_DROP = 0,
-          const bool IS_DTM = 0 // 是否开启确定性计算
+          const bool IS_DTM = 0, // 是否开启确定性计算
+          const bool HAS_SOFTCAP = 0
           >
 CATLASS_GLOBAL void FAGGeneral(uint64_t fftsAddr, GM_ADDR dout, GM_ADDR q, GM_ADDR k,
                         GM_ADDR v, GM_ADDR out, GM_ADDR drop_mask,
@@ -1088,7 +1089,7 @@ CATLASS_GLOBAL void FAGGeneral(uint64_t fftsAddr, GM_ADDR dout, GM_ADDR q, GM_AD
     using EpilogueFAGSfmg = Catlass::Epilogue::Block::BlockEpilogue<EpilogueAtlasA2FAGSfmg, InputType, FAGTilingData>;
 
     // VEC_Op：计算S = Mask(Q*K^T)，并完成重计算 P = Softmax(S)，再计算dS = P * Sub(dP, Sfmg)
-    using EpilogueAtlasA2SameAbVec = Catlass::Epilogue::EpilogueAtlasA2SameAbVec<INPUT_LAYOUT, IS_DROP, IS_ATTEN_MASK>;
+    using EpilogueAtlasA2SameAbVec = Catlass::Epilogue::EpilogueAtlasA2SameAbVec<INPUT_LAYOUT, IS_DROP, IS_ATTEN_MASK, HAS_SOFTCAP>;
     using EpilogueFAGSabVec = Catlass::Epilogue::Block::BlockEpilogue<EpilogueAtlasA2SameAbVec, OutputType, InputType, FAGTilingData>;
 
     // VEC_Post：dQ*scale和dK*scale，并搬运输出dQ/dK/dV

--- a/csrc/arch22/flash_attn_npu_v3/fag_tiling.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/fag_tiling.cpp
@@ -290,6 +290,7 @@ void DoPreSfmgTiling(FAGTilingData &fagTilingData)
 int64_t GetFAGTilingParam(const FAGInfo &fagInfo, uint32_t aicNum, uint32_t aivNum, uint64_t ubSize, FAGTilingData &fagTilingData)
 {
     fagTilingData.scaleValue = fagInfo.scaleValue;
+    fagTilingData.softcapValue = fagInfo.softcapValue;
     fagTilingData.keepProb = fagInfo.keepProb;
     fagTilingData.batch = fagInfo.batch;
     fagTilingData.qSeqlen = fagInfo.qSeqlen;

--- a/csrc/arch22/flash_attn_npu_v3/fag_tiling.h
+++ b/csrc/arch22/flash_attn_npu_v3/fag_tiling.h
@@ -53,6 +53,7 @@ constexpr int64_t ATTEN_MASK_COMPRESS_DIM = 2048;
 
 struct FAGInfo {
     float scaleValue;
+    float softcapValue;
     float keepProb;
     int32_t maskType = 0;
     int32_t layout = 0;

--- a/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
+++ b/csrc/arch22/flash_attn_npu_v3/flash_api.cpp
@@ -597,10 +597,10 @@ mha_bwd(at::Tensor dout,  // (b, s_q, h, dv) or (total_q, h, dv) if there is cu_
 
     const bool is_varlen_q = cu_seqlens_q_.has_value();
     const bool is_varlen_kv = cu_seqlens_k_.has_value();
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
     TORCH_CHECK(!is_varlen_q || is_varlen_kv, "If cu_seqlens_q is provided in bwd, cu_seqlens_k must also be provided");
     TORCH_CHECK(!seqused_q_.has_value(), "mha_bwd does not support seqused_q yet.");
     TORCH_CHECK(!seqused_k_.has_value(), "mha_bwd does not support seqused_k yet.");
-    TORCH_CHECK(softcap == 0.0, "mha_bwd does not support softcap yet.");
     TORCH_CHECK(sm_margin == 0, "mha_bwd does not support sm_margin yet.");
 
     at::Tensor cu_seqlens_q;
@@ -638,6 +638,11 @@ mha_bwd(at::Tensor dout,  // (b, s_q, h, dv) or (total_q, h, dv) if there is cu_
     FAGTiling::FAGInfo fagInfo;
     fagInfo.scaleValue =
         softmax_scale_.has_value() ? static_cast<float>(softmax_scale_.value()) : 1.0f / sqrt(static_cast<float>(qk_headdim));
+    bool has_softcap = (softcap > 0.0f);
+    if (has_softcap) {
+        fagInfo.scaleValue = fagInfo.scaleValue / softcap;
+    }
+    fagInfo.softcapValue = softcap;
     fagInfo.keepProb = 1.0f;
     if (window_size_left >= max_seqlen_k - 1) {
         window_size_left = -1;
@@ -768,6 +773,7 @@ mha_bwd(at::Tensor dout,  // (b, s_q, h, dv) or (total_q, h, dv) if there is cu_
     bwd_args.aclStream = aclStream;
     bwd_args.fftsAddr = fftsAddr;
     bwd_args.is_bf16 = is_bf16;
+    bwd_args.is_softcap = has_softcap;
     bwd_args.has_attn_mask = has_attn_mask;
     bwd_args.deterministic = deterministic;
     bwd_args.qk_headdim_kernel = qk_headdim_kernel;

--- a/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/online_softmax.hpp
@@ -74,18 +74,16 @@ public:
         constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        
         constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t SOFTCAP_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
-
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
-
-        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
@@ -94,6 +92,7 @@ public:
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
         maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
         maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
+        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
         lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
@@ -101,8 +100,6 @@ public:
         llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
-        tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
-        softcapUbTensor = resource.ubBuf.template GetBufferByByte<float>(SOFTCAP_UB_TENSOR_OFFSET);
     }
 
     template <typename T>
@@ -408,27 +405,15 @@ public:
 
     __aicore__ inline void OperatePreMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
     {
-        UpCastMask<half, ElementMask>(
-            maskUbTensor16,
-            maskUbTensor,
-            rowNumCurLoop,
-            columnNumRound
-        );
-        AscendC::CompareScalar(
-            maskUbTensor,
-            maskUbTensor16,
-            static_cast<half>(1.0),
-            AscendC::CMPMODE::NE,
-            REPEAT_SIZE_IN_BYTE / sizeof(half),
-            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
-            AscendC::UnaryRepeatParams(1, 1, 8, 8)
-        );
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Select(maskUbTensor16, maskUbTensor, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
-        AscendC::PipeBarrier<PIPE_V>();
+        UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
         UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+        // 0 -> 1, 1 -> 0
+        uint32_t repeatTimes = CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE);
+        AscendC::UnaryRepeatParams repeatParams(1, 1, 8, 8);
+        AscendC::Adds<float, false>(maskUbTensor32, maskUbTensor32, -1.0f, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Abs<float, false>(maskUbTensor32, maskUbTensor32, (uint64_t)0, repeatTimes, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
     }
 
     __aicore__ inline void OperateNextMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
@@ -525,11 +510,11 @@ public:
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], 1.0f, (uint64_t)0, repeatTimes, repeatParams);
 
-        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, repeatTimes, 1, 8);
+        AscendC::Duplicate<float, false>(softcapUbTensor, 2 * softcapValue, (uint64_t)0, 1, 1, 8);
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Div<float, false>(
             lsUbTensor[sUbOffset], softcapUbTensor, lsUbTensor[sUbOffset], (uint64_t)0, repeatTimes,
-            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 0, 8));
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Adds<float, false>(
             lsUbTensor[sUbOffset], lsUbTensor[sUbOffset], -softcapValue, (uint64_t)0, repeatTimes, repeatParams);
@@ -1076,7 +1061,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
                 UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
                 UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
-                
+
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
                 if constexpr (HAS_SOFTCAP_) {
@@ -1256,8 +1241,9 @@ public:
                 uint32_t rowNumCurLoop =
                     (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
 
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);    
                 if (doTriUPreMask && doTriUNextMask) {
+                    // *** TriUPreMask
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                     ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
@@ -1267,26 +1253,25 @@ public:
                     ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundPre,
                               addMaskUbOffset);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                    if (doTriUNextMask) {
-                        uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
-                        // the token num of the prologue part
-                        uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
-                                               tokenNumPerHeadThisSubBlock;
-                        // the token num of the epilogue part
-                        uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
-                        // the number of integral heads within a cycle
-                        uint32_t epiTokenNum =
-                            rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
-                        CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
-                                       tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
-                                       epiTokenNum, true);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
-                        OperateNextMaskUb(rowNumCurLoop, columnNumRound);
-                        ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
-                                  addMaskUbOffset);
-                    }
+                    // *** TriUNextMask
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum = Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
+                                            tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum =
+                        rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                    CopyMaskGmToUb(gMaskThisSubBlockNext, maskColumnNext, columnNumRoundNext, maskStride,
+                                    tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum,
+                                    epiTokenNum, true);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                    OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                    ApplyMask((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumRoundNext,
+                                addMaskUbOffset);
                 } else if (doTriUPreMask) {
                     OperatePreMaskUb(rowNumCurLoop, columnNumRound);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
@@ -1372,7 +1357,6 @@ private:
     AscendC::LocalTensor<float> dmUbTensor;
     AscendC::LocalTensor<float> llUbTensor;
     AscendC::LocalTensor<float> tvUbTensor;
-    AscendC::LocalTensor<half> tempMaskTensor;
     AscendC::LocalTensor<float> glUbTensor;
     AscendC::LocalTensor<float> softcapUbTensor;
 };

--- a/csrc/arch22/flash_attn_npu_v3/rescale_o.hpp
+++ b/csrc/arch22/flash_attn_npu_v3/rescale_o.hpp
@@ -86,8 +86,8 @@ public:
         // Allocate UB space
         constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
-        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
 
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
         constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
@@ -102,7 +102,7 @@ public:
         goUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(GO_UB_TENSOR_OFFSET);
         hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
         gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
-        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
+        lseUbTensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
     }
 
     __aicore__ inline
@@ -141,7 +141,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -157,7 +157,7 @@ public:
                 (end - start) * FLOAT_BLOCK_SIZE
             );
             AscendC::Duplicate(
-                lse32_ubuf_tensor[start],
+                lseUbTensor[start],
                 LSE_OUT_INI,
                 (end - start)
             );
@@ -519,15 +519,15 @@ public:
                 if (isLastRowLoop) {
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Ln<float, false>(
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
                         glUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                     AscendC::PipeBarrier<PIPE_V>();
                     AscendC::Add<float, false>(
-                        lse32_ubuf_tensor,
-                        lse32_ubuf_tensor,
+                        lseUbTensor,
+                        lseUbTensor,
                         gmUbTensor,
                         (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                         AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -536,7 +536,7 @@ public:
                     // *** lse_block = expand_to_block(lse)
                     AscendC::Brcb(
                         tvUbTensor.ReinterpretCast<uint32_t>(),
-                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        lseUbTensor.ReinterpretCast<uint32_t>(),
                         CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                         AscendC::BrcbRepeatParams(1, 8));
                     InvalidLineLSEProcess(qNThisSubBlock, delStartRow, qSBlockIdx,
@@ -567,7 +567,7 @@ public:
                         if (qNThisSubBlock == 0U) {
                             // single head: its tokens are contiguous in BNS/NT -> plain lse32 burst.
                             AscendC::DataCopyPad(
-                                gLse, lse32_ubuf_tensor,
+                                gLse, lseUbTensor,
                                 AscendC::DataCopyExtParams(1, totalRowNum * sizeof(float), 0, 0, 0));
                         } else {
                             // multi-head: per-token gather (srcStride) + scatter (dstStride).
@@ -592,15 +592,15 @@ public:
                     if (isLastRowLoop) {
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Ln<float, false>(
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
                             glUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::UnaryRepeatParams(1, 1, 8, 8));
 
                         AscendC::PipeBarrier<PIPE_V>();
                         AscendC::Add<float, false>(
-                            lse32_ubuf_tensor,
-                            lse32_ubuf_tensor,
+                            lseUbTensor,
+                            lseUbTensor,
                             gmUbTensor,
                             (uint64_t)0, CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
                             AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
@@ -608,7 +608,7 @@ public:
 
                         AscendC::Brcb(
                             tvUbTensor.ReinterpretCast<uint32_t>(),
-                            lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                            lseUbTensor.ReinterpretCast<uint32_t>(),
                             CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
                             AscendC::BrcbRepeatParams(1, 8));
                         AscendC::PipeBarrier<PIPE_V>();
@@ -802,7 +802,7 @@ private:
     AscendC::LocalTensor<ElementOutput> goUbTensor16;
     AscendC::LocalTensor<float> goUbTensor32;
     AscendC::LocalTensor<float> gmUbTensor;
-    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+    AscendC::LocalTensor<float> lseUbTensor;
 };
 
 }

--- a/tests/fa_small_op_golden.py
+++ b/tests/fa_small_op_golden.py
@@ -78,6 +78,16 @@ def _keep_prob(dropout_p):
     return 1.0 - dropout_p
 
 
+def _softcap_backward_factor(q, k, scale, softcap, compute_dtype, *, gtype=torch.float64):
+    if softcap <= 0.0:
+        return None
+    qb = q.to(compute_dtype)
+    kb = k.to(compute_dtype)
+    qk = torch.matmul(qb, kb.permute(0, 1, 3, 2)).to(torch.float32).mul(scale)
+    tanh_qk = torch.tanh(qk.to(gtype) / softcap)
+    return 1.0 - tanh_qk * tanh_qk
+
+
 def sum_gqa_grad(dk_or_dv, nheads, nheads_k, batch, seq_k, headdim):
     if nheads == nheads_k:
         return dk_or_dv
@@ -96,6 +106,7 @@ def softmax_res_from_fa_lse_bsnd(
     k_bn,
     softmax_lse,
     scale,
+    softcap,
     is_causal,
     window_size_left,
     window_size_right,
@@ -110,6 +121,8 @@ def softmax_res_from_fa_lse_bsnd(
     qb = q_bn.to(compute_dtype)
     kb = k_bn.to(compute_dtype)
     qk = torch.matmul(qb, kb.permute(0, 1, 3, 2)).to(torch.float32).mul(scale)
+    if softcap > 0.0:
+        qk = softcap * torch.tanh(qk / softcap)
     if atten_mask is not None and len(atten_mask.shape) != 0:
         qk = qk + atten_mask.to(torch.float32) * (-40000.0)
     lse = softmax_lse.to(torch.float32).to(gtype)
@@ -127,6 +140,7 @@ def softmax_res_from_fa_lse_tnd_slice(
     k_bn,
     softmax_lse_nt_slice,
     scale,
+    softcap,
     is_causal,
     window_size_left,
     window_size_right,
@@ -141,6 +155,8 @@ def softmax_res_from_fa_lse_tnd_slice(
     qb = q_bn.to(compute_dtype)
     kb = k_bn.to(compute_dtype)
     qk = torch.matmul(qb, kb.permute(0, 1, 3, 2)).to(torch.float32).mul(scale)
+    if softcap > 0.0:
+        qk = softcap * torch.tanh(qk / softcap)
     if atten_mask is not None and len(atten_mask.shape) != 0:
         qk = qk + atten_mask.to(torch.float32) * (-40000.0)
     lse = softmax_lse_nt_slice.to(torch.float32).to(gtype).unsqueeze(0).unsqueeze(-1)
@@ -150,7 +166,7 @@ def softmax_res_from_fa_lse_tnd_slice(
     return softmax_res
 
 
-def tbackward_bsnd(dx, q, k, v, softmax_res, drop_mask, scale, dropout_p):
+def tbackward_bsnd(dx, q, k, v, softmax_res, drop_mask, scale, softcap, dropout_p):
     keep_prob = _keep_prob(dropout_p)
     dp = torch.matmul(dx, v.permute(0, 1, 3, 2))
     if drop_mask is None or len(drop_mask.shape) == 0:
@@ -161,12 +177,15 @@ def tbackward_bsnd(dx, q, k, v, softmax_res, drop_mask, scale, dropout_p):
         dp_drop = dp * drop_mask * (1.0 / keep_prob)
     dv = torch.matmul(drop_res, dx)
     softmax_grad_res = tsoftmax_grad(dp_drop, softmax_res) * scale
+    softcap_factor = _softcap_backward_factor(q, k, scale, softcap, q.dtype)
+    if softcap_factor is not None:
+        softmax_grad_res = softmax_grad_res * softcap_factor
     dq = torch.matmul(softmax_grad_res, k)
     dk = torch.matmul(softmax_grad_res.permute(0, 1, 3, 2), q)
     return dq, dk, dv
 
 
-def tbackward_tnd(dx, q, k, v, softmax_res, drop_mask, scale, dropout_p):
+def tbackward_tnd(dx, q, k, v, softmax_res, drop_mask, scale, softcap, dropout_p):
     keep_prob = _keep_prob(dropout_p)
     if drop_mask is None or len(drop_mask.shape) == 0:
         drop_res = softmax_res.permute(0, 1, 3, 2)
@@ -177,6 +196,9 @@ def tbackward_tnd(dx, q, k, v, softmax_res, drop_mask, scale, dropout_p):
         dp_drop = dp * drop_mask * (1.0 / keep_prob)
     dv = torch.matmul(drop_res, dx)
     softmax_grad_res = tsoftmax_grad(dp_drop, softmax_res) * scale
+    softcap_factor = _softcap_backward_factor(q, k, scale, softcap, q.dtype)
+    if softcap_factor is not None:
+        softmax_grad_res = softmax_grad_res * softcap_factor
     dq = torch.matmul(softmax_grad_res, k)
     dk = torch.matmul(softmax_grad_res.permute(0, 1, 3, 2), q)
     return dq, dk, dv
@@ -192,6 +214,7 @@ def golden_bsnd_bwd_from_fwd(
     nheads,
     nheads_k,
     scale,
+    softcap,
     dropout_p,
     is_causal,
     window_size_left,
@@ -222,6 +245,7 @@ def golden_bsnd_bwd_from_fwd(
         k_new,
         lse_cpu,
         scale,
+        softcap,
         is_causal,
         window_size_left,
         window_size_right,
@@ -230,7 +254,7 @@ def golden_bsnd_bwd_from_fwd(
     )
     drop_mask = torch.tensor(1)
     dq_bn, dk_bn, dv_bn = tbackward_bsnd(
-        dx_bn, q_bn, k_new, v_new, softmax_res, drop_mask, scale, dropout_p
+        dx_bn, q_bn, k_new, v_new, softmax_res, drop_mask, scale, softcap, dropout_p
     )
     dk_bn = sum_gqa_grad(dk_bn, nheads, nheads_k, batch, seq_k, headdim)
     dv_bn = sum_gqa_grad(dv_bn, nheads, nheads_k, batch, seq_k, headdim)
@@ -253,6 +277,7 @@ def golden_tnd_bwd_from_fwd(
     seqlens_q,
     seqlens_k,
     scale,
+    softcap,
     dropout_p,
     is_causal,
     window_size_left,
@@ -302,6 +327,7 @@ def golden_tnd_bwd_from_fwd(
             ki_new,
             lse_i,
             scale,
+            softcap,
             is_causal,
             window_size_left,
             window_size_right,
@@ -309,7 +335,7 @@ def golden_tnd_bwd_from_fwd(
             gtype=gtype,
         )
         dqi, dki, dvi = tbackward_tnd(
-            dxi, qi, ki_new, vi_new, softmax_res_i, drop_mask, scale, dropout_p
+            dxi, qi, ki_new, vi_new, softmax_res_i, drop_mask, scale, softcap, dropout_p
         )
         dki = sum_gqa_grad(dki, nheads, nheads_k, 1, sk, headdim)
         dvi = sum_gqa_grad(dvi, nheads, nheads_k, 1, sk, headdim)

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -423,6 +423,11 @@ test_cases = [
     (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
     (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
     (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    # Softcap
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 50.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 50.0),
 ]
 @pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
 def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):

--- a/tests/test_flash_attn_npu_v2_bwd.py
+++ b/tests/test_flash_attn_npu_v2_bwd.py
@@ -19,7 +19,7 @@ import pytest
 import torch
 import torch_npu
 
-from flash_attn_npu_v2 import flash_attn_varlen_func, flash_attn_func
+from flash_attn_npu_v2 import flash_attn_func, flash_attn_varlen_func
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 if TESTS_DIR not in sys.path:
@@ -42,8 +42,7 @@ def golden_tolerance(_data_type):
 def assert_grad_close(fa_grad, golden_grad, data_type, name=""):
     rtol, atol = golden_tolerance(data_type)
     torch.testing.assert_close(
-        fa_grad.cpu(), golden_grad.cpu(), rtol=rtol, atol=atol,
-        msg=f"{name} grad mismatch (rtol={rtol}, atol={atol})",
+        fa_grad.cpu(), golden_grad.cpu(), rtol=rtol, atol=atol
     )
 
 
@@ -75,7 +74,7 @@ def rand_inputs(shape, data_type, device):
 
 def run_bsnd_bwd(
     query, key, value, dout, data_type,
-    num_heads, kv_heads, scale, is_causal, window_size=(-1, -1),
+    num_heads, kv_heads, scale, softcap, is_causal, window_size=(-1, -1),
 ):
     q_ag = query.detach().clone().requires_grad_(True)
     k_ag = key.detach().clone().requires_grad_(True)
@@ -85,6 +84,7 @@ def run_bsnd_bwd(
         q_ag, k_ag, v_ag,
         dropout_p=DROPOUT_P,
         softmax_scale=scale,
+        softcap=softcap,
         causal=is_causal,
         window_size=window_size,
         return_attn_probs=True,
@@ -94,7 +94,7 @@ def run_bsnd_bwd(
 
     dq_golden, dk_golden, dv_golden = golden_bsnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, scale, DROPOUT_P,
+        num_heads, kv_heads, scale, softcap, DROPOUT_P,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
     )
@@ -106,7 +106,7 @@ def run_varlen_bwd(
     cu_seqlens_q, cu_seqlens_k,
     max_seqlen_q, max_seqlen_k,
     seqlens_q, seqlens_k,
-    scale, is_causal, window_size=(-1, -1),
+    scale, softcap, is_causal, window_size=(-1, -1),
 ):
     num_heads = query.shape[1]
     kv_heads = key.shape[1]
@@ -121,6 +121,7 @@ def run_varlen_bwd(
         max_seqlen_q, max_seqlen_k,
         dropout_p=DROPOUT_P,
         softmax_scale=scale,
+        softcap=softcap,
         causal=is_causal,
         window_size=window_size,
         return_attn_probs=True,
@@ -130,7 +131,7 @@ def run_varlen_bwd(
 
     dq_golden, dk_golden, dv_golden = golden_tnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, seqlens_q, seqlens_k, scale, DROPOUT_P,
+        num_heads, kv_heads, seqlens_q, seqlens_k, scale, softcap, DROPOUT_P,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
     )
@@ -144,23 +145,31 @@ def assert_bwd_results(data_type, dq_ag, dk_ag, dv_ag, dq_golden, dk_golden, dv_
 
 
 test_cases_bsnd = [
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False),
-    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 0.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 30.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
     test_cases_bsnd,
 )
 def test_fa_bsnd_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal,
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap,
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -170,31 +179,39 @@ def test_fa_bsnd_bwd(
     scale = 1.0 / (head_size ** 0.5)
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
-        num_heads, kv_heads, scale, is_causal, (-1, -1),
+        num_heads, kv_heads, scale, softcap, is_causal, (-1, -1),
     )
     assert_bwd_results(*results)
 
 
 test_cases_bsnd_swa = [
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256),
-    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 30.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 30.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right",
+    "is_causal, window_size_left, window_size_right, softcap",
     test_cases_bsnd_swa,
 )
 def test_fa_bsnd_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right,
+    is_causal, window_size_left, window_size_right, softcap
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -205,27 +222,33 @@ def test_fa_bsnd_bwd_swa(
     window_size = (window_size_left, window_size_right)
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
-        num_heads, kv_heads, scale, is_causal, window_size,
+        num_heads, kv_heads, scale, softcap, is_causal, window_size,
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen = [
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True),
-    (torch.float16, 1, 5, 1, 512, 512, 128, True),
-    (torch.float16, 1, 5, 1, 777, 888, 192, False),
-    (torch.float16, 1, 5, 1, 1777, 1888, 256, True),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True),
-    (torch.bfloat16, 1, 5, 1, 711, 8192, 111, True),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 0.0),
+    (torch.float16, 1, 5, 1, 512, 512, 128, True, 0.0),
+    (torch.float16, 1, 5, 1, 777, 888, 192, False, 0.0),
+    (torch.float16, 1, 5, 1, 1777, 1888, 256, True, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, 0.0),
+    (torch.bfloat16, 1, 5, 1, 711, 8192, 111, True, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 30.0),
+    (torch.float16, 1, 5, 1, 512, 512, 128, True, 30.0),
+    (torch.float16, 1, 5, 1, 777, 888, 192, False, 30.0),
+    (torch.float16, 1, 5, 1, 1777, 1888, 256, True, 30.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, 30.0),
+    (torch.bfloat16, 1, 5, 1, 711, 8192, 111, True, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
     test_cases_varlen,
 )
 def test_fa_varlen_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal,
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap
 ):
     total_q = batch_size * q_seqlen
     total_k = batch_size * kv_seqlen
@@ -245,26 +268,29 @@ def test_fa_varlen_bwd(
         cu_seqlens_q, cu_seqlens_k,
         q_seqlen, kv_seqlen,
         seqlens_q, seqlens_k,
-        scale, is_causal, (-1, -1),
+        scale, softcap, is_causal, (-1, -1),
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen_swa = [
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256),
-    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256, 0.0),
+    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
+     (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256, 30.0),
+    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right",
+    "is_causal, window_size_left, window_size_right, softcap",
     test_cases_varlen_swa,
 )
 def test_fa_varlen_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right,
+    is_causal, window_size_left, window_size_right, softcap
 ):
     total_q = batch_size * q_seqlen
     total_k = batch_size * kv_seqlen
@@ -285,6 +311,6 @@ def test_fa_varlen_bwd_swa(
         cu_seqlens_q, cu_seqlens_k,
         q_seqlen, kv_seqlen,
         seqlens_q, seqlens_k,
-        scale, is_causal, window_size,
+        scale, softcap, is_causal, window_size,
     )
     assert_bwd_results(*results)

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -162,7 +162,7 @@ test_cases = [
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, True, "BSND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 1, 1, 1, 1024, 128, 1, 128, False, "BSND", False, -1, -1, 0.0),
     # kv=4096 -> 8 S2 blocks: num_splits=2 -> 2 segs (4 blk each), num_splits=4 -> 4 segs (2 blk each).
-        (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 2, 1, 1, 1, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.float16, 2, 2, 1, 128, 128, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 2, 6, 2, 2, 1024, 128, 1, 128, True, "TND", False, -1, -1, 0.0),
@@ -264,7 +264,7 @@ test_cases = [
     (torch.bfloat16, 1, 10, 2, 10, 4096, 256, 1, 128, True, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 8, 2, 8, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
     (torch.bfloat16, 1, 16, 2, 16, 2048, 128, 1, 128, False, "TND", False, -1, -1, 0.0),
-
+    # Softcap
     (torch.bfloat16, 1, 32, 8, 128, 4096, 128, 1, 128, False, "BSND", False, -1, -1, 30.0),
     (torch.bfloat16, 2, 16, 4, 256, 2048, 128, 1, 128, True, "BSND", False, -1, -1, 50.0),
     (torch.bfloat16, 1, 32, 4, 65, 2048, 256, 1, 128, False, "BSND", False, -1, -1, 50.0),
@@ -536,8 +536,11 @@ test_cases = [
     (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
     (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
     (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
+    # Softcap
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 50.0),
     (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 50.0)
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 50.0),
 ]
 @pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
 def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):

--- a/tests/test_flash_attn_npu_v3_bwd.py
+++ b/tests/test_flash_attn_npu_v3_bwd.py
@@ -78,7 +78,7 @@ def rand_inputs(shape, data_type, device):
 
 def run_bsnd_bwd(
     query, key, value, dout, data_type,
-    num_heads, kv_heads, scale, is_causal, window_size=(-1, -1),
+    num_heads, kv_heads, scale, softcap, is_causal, window_size=(-1, -1),
 ):
     q_ag = query.detach().clone().requires_grad_(True)
     k_ag = key.detach().clone().requires_grad_(True)
@@ -89,7 +89,7 @@ def run_bsnd_bwd(
         softmax_scale=scale,
         causal=is_causal,
         window_size=list(window_size),
-        softcap=0.0,
+        softcap=softcap,
         return_attn_probs=True,
     )
     dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_fa, (q_ag, k_ag, v_ag), dout)
@@ -97,7 +97,7 @@ def run_bsnd_bwd(
 
     dq_golden, dk_golden, dv_golden = golden_bsnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, scale, DROPOUT_P,
+        num_heads, kv_heads, scale, softcap, DROPOUT_P,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
     )
@@ -109,7 +109,7 @@ def run_varlen_bwd(
     cu_seqlens_q, cu_seqlens_k,
     max_seqlen_q, max_seqlen_k,
     seqlens_q, seqlens_k,
-    scale, is_causal, window_size=(-1, -1),
+    scale, softcap, is_causal, window_size=(-1, -1),
 ):
     num_heads = query.shape[1]
     kv_heads = key.shape[1]
@@ -125,7 +125,7 @@ def run_varlen_bwd(
         softmax_scale=scale,
         causal=is_causal,
         window_size=window_size,
-        softcap=0.0,
+        softcap=softcap,
         return_attn_probs=True,
     )
     dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_fa, (q_ag, k_ag, v_ag), dout)
@@ -133,7 +133,7 @@ def run_varlen_bwd(
 
     dq_golden, dk_golden, dv_golden = golden_tnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, seqlens_q, seqlens_k, scale, DROPOUT_P,
+        num_heads, kv_heads, seqlens_q, seqlens_k, scale, softcap, DROPOUT_P,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
     )
@@ -147,23 +147,31 @@ def assert_bwd_results(data_type, dq_ag, dk_ag, dv_ag, dq_golden, dk_golden, dv_
 
 
 test_cases_bsnd = [
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False),
-    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 0.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 30.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 30.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
     test_cases_bsnd,
 )
 def test_fa_bsnd_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal,
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap,
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -173,31 +181,39 @@ def test_fa_bsnd_bwd(
     scale = 1.0 / (head_size ** 0.5)
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
-        num_heads, kv_heads, scale, is_causal, (-1, -1),
+        num_heads, kv_heads, scale, softcap, is_causal, (-1, -1),
     )
     assert_bwd_results(*results)
 
 
 test_cases_bsnd_swa = [
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256),
-    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 30.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 30.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 30.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right",
+    "is_causal, window_size_left, window_size_right, softcap",
     test_cases_bsnd_swa,
 )
 def test_fa_bsnd_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right,
+    is_causal, window_size_left, window_size_right, softcap
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -208,29 +224,37 @@ def test_fa_bsnd_bwd_swa(
     window_size = (window_size_left, window_size_right)
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
-        num_heads, kv_heads, scale, is_causal, window_size,
+        num_heads, kv_heads, scale, softcap, is_causal, window_size,
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen = [
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True),
-    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False),
-    (torch.float16, 7, 5, 1, 512, 512, 128, True),
-    (torch.float16, 7, 5, 1, 777, 888, 192, False),
-    (torch.float16, 7, 5, 1, 1777, 1888, 256, True),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True),
-    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True),
-    (torch.bfloat16, 1, 16, 16, 562, 562, 96, False),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 0.0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, 0.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, 0.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, 0.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, 0.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, 0.0),
+    (torch.bfloat16, 1, 16, 16, 562, 562, 96, False, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 30.0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, 30.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, 30.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, 30.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, 30.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, 30.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, 30.0),
+    (torch.bfloat16, 1, 16, 16, 562, 562, 96, False, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
     test_cases_varlen,
 )
 def test_fa_varlen_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal,
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap
 ):
     total_q = batch_size * q_seqlen
     total_k = batch_size * kv_seqlen
@@ -250,28 +274,33 @@ def test_fa_varlen_bwd(
         cu_seqlens_q, cu_seqlens_k,
         q_seqlen, kv_seqlen,
         seqlens_q, seqlens_k,
-        scale, is_causal, (-1, -1),
+        scale, softcap, is_causal, (-1, -1),
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen_swa = [
-    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0),
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256),
-    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128),
-    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, -128, 864),
+    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256, 0.0),
+    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
+    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, -128, 864, 0.0),
+    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, False, 0, 256, 30.0),
+    (torch.float16, 1, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
+    (torch.bfloat16, 1, 4, 4, 1024, 1024, 128, True, -128, 864, 30.0),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right",
+    "is_causal, window_size_left, window_size_right, softcap",
     test_cases_varlen_swa,
 )
 def test_fa_varlen_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right,
+    is_causal, window_size_left, window_size_right, softcap
 ):
     total_q = batch_size * q_seqlen
     total_k = batch_size * kv_seqlen
@@ -292,6 +321,6 @@ def test_fa_varlen_bwd_swa(
         cu_seqlens_q, cu_seqlens_k,
         q_seqlen, kv_seqlen,
         seqlens_q, seqlens_k,
-        scale, is_causal, window_size,
+        scale, softcap, is_causal, window_size,
     )
     assert_bwd_results(*results)


### PR DESCRIPTION
## Related Issue
<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

Refs https://github.com/MinghuasLab/flash-attention-npu/issues/65.


## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Add support for **softcapping** in the **backward** pass of **arch22 v2/v3**.

- Implemented softcapping recomputation and gradient calculation in the backward op epilogue.
- Added `HAS_SOFTCAP` template parameter in backward kernel.
- Updated backward test cases to verify softcapping functionality.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->

<img width="1557" height="276" alt="image" src="https://github.com/user-attachments/assets/1a0489f5-b6df-4644-92f1-ef45ee9acb22" />
<img width="1484" height="271" alt="image" src="https://github.com/user-attachments/assets/dfd723a6-8728-4229-8e63-081ba38ba4ba" />


## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->
None.