### PR TITLE
import so fix

### DIFF
--- a/flash_attn_npu/flash_attn_npu_interface.py
+++ b/flash_attn_npu/flash_attn_npu_interface.py
@@ -9,7 +9,7 @@ import os
 
 # isort: off
 # We need to import the kernels after importing torch
-import flash_attn_npu
+from . import flash_attn_npu
 # isort: on
 
 def maybe_contiguous(x):

--- a/flash_attn_npu_3/flash_attn_npu_interface.py
+++ b/flash_attn_npu_3/flash_attn_npu_interface.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 
 # isort: off
 # We need to import the kernels after importing torch
-import flash_attn_npu_3  # Registers operators with PyTorch
+from . import flash_attn_npu_3  # Registers operators with PyTorch
 
 # isort: on
 

--- a/flash_attn_npu_4/flash_attn_npu_interface.py
+++ b/flash_attn_npu_4/flash_attn_npu_interface.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 
 # isort: off
 # We need to import the kernels after importing torch
-import flash_attn_npu_4  # Registers operators with PyTorch
+from . import flash_attn_npu_4  # Registers operators with PyTorch
 
 # isort: on
 


### PR DESCRIPTION
## Related Issue
#94 

## Summary
setup.py：910 扩展改为包内子模块
flash_attn_npu.flash_attn_npu
flash_attn_npu_3.flash_attn_npu_3
flash_attn_npu_4.flash_attn_npu_4
接口改为相对导入：from . import flash_attn_npu_3（v2/v4 同理）
950 的 *_950 后缀无冲突，保持顶层模块与 import flash_attn_npu_3_950 不变

## Validation
A5
<img width="1400" height="294" alt="image" src="https://github.com/user-attachments/assets/af7d8169-e636-45f9-92e7-64ddac8d44c9" />

A3
<img width="1499" height="314" alt="image" src="https://github.com/user-attachments/assets/f338075b-3aa0-4e27-9e6c-6ed5c8db74ba" />

