### PR TITLE
feat: impl return_attn_probs in flash_attn_npu v2

### DIFF
--- a/csrc/ascend910/flash_attn_npu/fa_block.h
+++ b/csrc/ascend910/flash_attn_npu/fa_block.h
@@ -15,12 +15,13 @@ using namespace Catlass;
 
 namespace Catlass::Epilogue {
     enum class LseModeT {NONE = 0, OUT_ONLY = 1};
-    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_>
+    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_, bool RETURN_SOFTMAX_>
     struct EpilogueAtlasA2OnlineSoftmaxT {
         using ArchTag = Arch::AtlasA2;
         using IntermPrec = SM_DTYPE_;
         static constexpr LseModeT LSE_MODE = LSE_MODE_;
         static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
+        static constexpr bool RETURN_SOFTMAX = RETURN_SOFTMAX_;
     };
 
     template <LseModeT LSE_MODE_, typename SM_DTYPE_>

--- a/csrc/ascend910/flash_attn_npu/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu/flash_api.cpp
@@ -666,7 +666,6 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     TORCH_CHECK(!alibi_slopes_.has_value(), "NPU FlashAttention does not support alibi_slopes.");
     TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
     TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
-    TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
 
     TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
@@ -710,7 +709,8 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     auto opts = q.options().device(at::kPrivateUse1);
     auto p = torch::empty({0}, opts);
     if (return_softmax) {
-        p = torch::empty({batch_size, num_heads, seqlen_q, seqlen_k}, opts);
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::zeros({batch_size, num_heads, seqlen_q, seqlen_k}, opts);
     }
     auto rng_state = torch::empty({2}, opts.dtype(torch::kInt64));
 
@@ -778,11 +778,13 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     }
     tiling_cpu_ptr->set_softcapValue(softcap);
     tiling_cpu_ptr->set_maxQSeqlen(seqlen_q);
+    tiling_cpu_ptr->set_maxKvSeqlen(seqlen_k);
     tiling_cpu_ptr->set_mm1OutSize(mm1OutSize);
     tiling_cpu_ptr->set_smOnlineOutSize(smOnlineOutSize);
     tiling_cpu_ptr->set_mm2OutSize(mm2OutSize);
     tiling_cpu_ptr->set_UpdateSize(UpdateSize);
     tiling_cpu_ptr->set_workSpaceSize(workSpaceSize);
+    tiling_cpu_ptr->set_pDevice(return_softmax ? static_cast<uint8_t*>(const_cast<void*>(p.data_ptr())) : nullptr);
 
     uint32_t totalTaskNum = 0;
     uint32_t groupSize = num_heads / num_heads_k;
@@ -831,6 +833,7 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
     fwd_args.has_softcap = has_softcap;
+    fwd_args.return_softmax = return_softmax;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -890,19 +893,11 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
     TORCH_CHECK(!zero_tensors, "NPU FlashAttention does not support zero_tensors.");
     TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
-    TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
     TORCH_CHECK(k.dtype() == q.dtype(), "query and key must have the same dtype");
     TORCH_CHECK(v.dtype() == q.dtype(), "query and value must have the same dtype");
     TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-
-    at::Tensor out;
-    if (out_.has_value()) {
-        out = out_.value();
-    }  else {
-        out = torch::empty_like(q);
-    }
 
     // 可选输入，当前均不支持
     at::Tensor seqlens_k, leftpad_k, alibi_slopes, block_table;
@@ -974,6 +969,15 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         }
     }
 
+    at::Tensor out = (out_.has_value()) ? out_.value() : torch::empty_like(q);
+    auto opts = q.options().device(at::kPrivateUse1);
+    auto p = torch::empty({0}, opts);
+    if (return_softmax) {
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::zeros({batch_size, num_heads, max_seqlen_q, max_seqlen_k}, opts);
+    }
+    auto rng_state = torch::empty({2}, opts.dtype(torch::kInt64));
+
     tiling_cpu_ptr->set_batch(static_cast<uint32_t>(batch_size));
     tiling_cpu_ptr->set_numHeads(static_cast<uint32_t>(num_heads));
     tiling_cpu_ptr->set_kvHeads(static_cast<uint32_t>(num_heads_k));
@@ -997,6 +1001,8 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     }
     tiling_cpu_ptr->set_softcapValue(softcap);
     tiling_cpu_ptr->set_maxQSeqlen(max_seqlen_q);
+    tiling_cpu_ptr->set_maxKvSeqlen(max_seqlen_k);
+    tiling_cpu_ptr->set_pDevice(return_softmax ? static_cast<uint8_t*>(const_cast<void*>(p.data_ptr())) : nullptr);
 
     uint64_t WORKSPACE_BLOCK_SIZE_DB = 128 * 512;  // 工作空间块大小 ，每次计算128 * 512
     uint64_t PRELANCH_NUM = 3;
@@ -1089,6 +1095,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
     fwd_args.has_softcap = has_softcap;
+    fwd_args.return_softmax = return_softmax;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -1102,9 +1109,6 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     fwd_args.tilingDevice = tilingDevice;
     launch_fwd<true>(fwd_args);
 
-    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(at::Device(at::kPrivateUse1));
-    at::Tensor rng_state =  torch::empty({2}, options.dtype(torch::kInt64));
-    at::Tensor p = torch::empty({ 0 }, options.dtype(torch::kInt64));
     return {out, softmaxlse, p, rng_state};
 }
 

--- a/csrc/ascend910/flash_attn_npu/fwd_dispatch.hpp
+++ b/csrc/ascend910/flash_attn_npu/fwd_dispatch.hpp
@@ -36,6 +36,7 @@ struct FwdLaunchArgs {
     bool is_local;              // sliding-window attention (MASK_SWA)
     bool flashDecodeFlag;       // only meaningful for the BSND (kvcache) path
     bool has_softcap;
+    bool return_softmax = false;
     uint8_t *qDevice;
     uint8_t *kDevice;
     uint8_t *vDevice;

--- a/csrc/ascend910/flash_attn_npu/fwd_dispatch_impl.hpp
+++ b/csrc/ascend910/flash_attn_npu/fwd_dispatch_impl.hpp
@@ -40,6 +40,7 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
     const bool is_local = a.is_local;
     const bool flashDecodeFlag = a.flashDecodeFlag;
     const bool has_softcap = a.has_softcap;
+    const bool return_softmax = a.return_softmax;
     uint8_t *qDevice = a.qDevice;
     uint8_t *kDevice = a.kDevice;
     uint8_t *vDevice = a.vDevice;
@@ -56,17 +57,33 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
     if (paged_KV) {
         if (is_local) {
             if (has_softcap) {
-                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             } else {
-                SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             }
         } else if (is_causal) {
             // Flash-decode (8th template param = true) is a BSND-only path
@@ -75,137 +92,281 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
             if constexpr (!IS_TND) {
                 if (flashDecodeFlag) {
                     if (has_softcap) {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     } else {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     }
                 } else {
                     if (has_softcap) {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     } else {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     }
                 }
             } else {
                 if (has_softcap) {
-                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                        <<<blockDim, nullptr, aclStream>>>(
-                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    if (return_softmax) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
                 } else {
-                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                        <<<blockDim, nullptr, aclStream>>>(
-                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    if (return_softmax) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::MASK_CAUSAL,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
                 }
             }
         } else {
             if constexpr (!IS_TND) {
                 if (flashDecodeFlag) {
                     if (has_softcap) {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, true, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     } else {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, true, false, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     }
                 } else {
                     if (has_softcap) {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     } else {
-                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                            <<<blockDim, nullptr, aclStream>>>(
-                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                                qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        if (return_softmax) {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        } else {
+                            SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                                LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                                <<<blockDim, nullptr, aclStream>>>(
+                                    fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                    softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                        }
                     }
                 }
             } else {
                 if (has_softcap) {
-                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                        <<<blockDim, nullptr, aclStream>>>(
-                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    if (return_softmax) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
                 } else {
-                    SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
-                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                        <<<blockDim, nullptr, aclStream>>>(
-                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    if (return_softmax) {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    } else {
+                        SplitFuse::FAInfer<DType, DType, float, true, FaiKenel::MaskType::NO_MASK,
+                            LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                            <<<blockDim, nullptr, aclStream>>>(
+                                fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice,
+                                softmaxLseDevice, qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                    }
                 }
             }
         }
     } else {
         if (is_local) {
             if (has_softcap) {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             } else {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_SWA,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             }
         } else if (is_causal) {
             if (has_softcap) {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             } else {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::MASK_CAUSAL,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             }
         } else {
             if (has_softcap) {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, true, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             } else {
-                SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
-                    LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false>
-                    <<<blockDim, nullptr, aclStream>>>(
-                        fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
-                        qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                if (return_softmax) {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, true>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                } else {
+                    SplitFuse::FAInfer<DType, DType, float, false, FaiKenel::MaskType::NO_MASK,
+                        LAYOUT, Catlass::Epilogue::LseModeT::OUT_ONLY, false, false, false>
+                        <<<blockDim, nullptr, aclStream>>>(
+                            fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice, oDevice, softmaxLseDevice,
+                            qSeqDevice, kvSeqDevice, workspaceDevice, tilingDevice);
+                }
             }
         }
     }

--- a/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
@@ -94,6 +94,7 @@ namespace SplitFuse {
             AscendC::GlobalTensor<ElementP>& gP;
             AscendC::GlobalTensor<ElementOTmp>& gOTmp;
             AscendC::GlobalTensor<ElementOTmp>& gOUpdate;
+            AscendC::GlobalTensor<ElementP>& gPret;
         };
 
         __aicore__ inline
@@ -122,6 +123,7 @@ namespace SplitFuse {
             scaleValue = fATilingData->scaleValue;
             softcapValue = fATilingData->softcapValue;
             maxQSeqlen = fATilingData->maxQSeqlen;
+            maxKvSeqlen = fATilingData->maxKvSeqlen;
 
             // FD workspace sizing: reserve head of workspace for gLseFD/gOFD.
             uint64_t Lsesize = 0;
@@ -167,13 +169,22 @@ namespace SplitFuse {
             AscendC::GlobalTensor<ElementOTmp> gOUpdate;
             gOUpdate.SetGlobalBuffer((__gm__ ElementOTmp *)(params.workSpace + Lsesize + Losize +
                 mm1OutSize + smOnlineOutSize + mm2OutSize));
+            
+            AscendC::GlobalTensor<ElementP> gPret;
+            gPret.SetGlobalBuffer((__gm__ ElementP *)(fATilingData->pDevice));
 
             GlobalTensorBundle globalTensors{
                 gQ, gK, gV, gMask, gBlockTable,
                 gActualQseqlen, gActualKvseqlen,
                 gO, gLse, gLseFD, gOFD,
-                gS, gP, gOTmp, gOUpdate
+                gS, gP, gOTmp, gOUpdate, gPret
             };
+
+            strideQ = static_cast<uint64_t>(qHeads * embed);
+            strideO = static_cast<uint64_t>(qHeads * embedV);
+            strideK = static_cast<uint64_t>(kvHeads * embed);
+            strideV = static_cast<uint64_t>(kvHeads * embedV);
+            stridePret = static_cast<uint64_t>(maxQSeqlen * maxKvSeqlen);
 
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
@@ -229,15 +240,12 @@ namespace SplitFuse {
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
 
-            epilogueOnlineSoftmax.init(resource, scaleValue, softcapValue);
+            epilogueOnlineSoftmax.init(resource, scaleValue, softcapValue, gPret, stridePret, maxKvSeqlen);
             epilogueRescaleO.init(resource);
 
             coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
 #endif
-            strideQ = static_cast<uint64_t>(qHeads * embed);
-            strideO = static_cast<uint64_t>(qHeads * embedV);
-            strideK = static_cast<uint64_t>(kvHeads * embed);
-            strideV = static_cast<uint64_t>(kvHeads * embedV);
+
             embedRound = RoundUp(embed, FaiKenel::BLOCK_SIZE);
             embedRoundV = RoundUp(embedV, FaiKenel::BLOCK_SIZE);
             groupSize = qHeads / kvHeads;
@@ -460,6 +468,7 @@ namespace SplitFuse {
             auto& gP = globalTensors.gP;
             auto& gOTmp = globalTensors.gOTmp;
             auto& gOUpdate = globalTensors.gOUpdate;
+            auto& gPret = globalTensors.gPret;
 
             uint32_t qSeqlen = maxQSeqlen;
             uint32_t kvSeqlen = static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx));
@@ -533,6 +542,9 @@ namespace SplitFuse {
             uint64_t gmOffsetLse = lseBOffset +
                 static_cast<uint64_t>(qNStartIdx) * lseHeadStride +
                 static_cast<uint64_t>(lseTokenOffset);
+
+            uint64_t gmOffsetPret = static_cast<uint64_t>(BIdx * qHeads + qNStartIdx) * stridePret +
+                                    static_cast<uint64_t>(qSBlockIdx * curQSBlockTile) * maxKvSeqlen;
 
             uint32_t qSBlockSize = (qSBlockIdx == (curQSBlockNum - 1U)) ?
                 (qSeqlen - qSBlockIdx * curQSBlockTile) : curQSBlockTile;
@@ -680,6 +692,7 @@ namespace SplitFuse {
                     uint64_t gmOffsetP = gmOffsetS;
                     uint32_t kvSStartIdx = kvSIdx * MAX_KV_STACK_LEN;
                     uint32_t kvSEndIdx = kvSStartIdx + stackSeqTile;
+                    epilogueOnlineSoftmax.set_gmOffsetPret(gmOffsetPret + kvSStartIdx);
                     if constexpr (MASK_TYPE == FaiKenel::MaskType::MASK_CAUSAL) {
                         uint32_t triUp = noSkipKvS - qSBlockSize;
                         uint32_t triDown = noSkipKvS;
@@ -990,11 +1003,13 @@ namespace SplitFuse {
         float    softcapValue;
         uint32_t totalQTokens;
         uint32_t maxQSeqlen;
+        uint32_t maxKvSeqlen;
 
         uint64_t strideQ;
         uint64_t strideO;
         uint64_t strideK;
         uint64_t strideV;
+        uint64_t stridePret;
         uint32_t embedRound;
         uint32_t embedRoundV;
         uint32_t groupSize;
@@ -1021,7 +1036,8 @@ namespace SplitFuse {
         FaiKenel::inputLayout inLayout = FaiKenel::inputLayout::TND,
         Epilogue::LseModeT lseMode = Epilogue::LseModeT::NONE,
         bool IS_FD = false,
-        bool HAS_SOFTCAP = false>
+        bool HAS_SOFTCAP = false,
+        bool RETURN_SOFTMAX = false>
     __global__ __aicore__ void FAInfer(
         uint64_t fftsAddr,
         GM_ADDR q,
@@ -1069,7 +1085,8 @@ namespace SplitFuse {
         using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK,
                                                    QType, KType, SType>;
 
-        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP>;
+        using DispatchPolicyOnlineSoftmax =
+            Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP, RETURN_SOFTMAX>;
         using PType = Gemm::GemmType<ElementP, LayoutP>;
         using maskType = Gemm::GemmType<ElementMask, LayoutMask>;
         using EpilogueOnlineSoftmax =

--- a/csrc/ascend910/flash_attn_npu/online_softmax.hpp
+++ b/csrc/ascend910/flash_attn_npu/online_softmax.hpp
@@ -23,15 +23,16 @@ template <
     class InputType_,
     class MaskType_,
     LseModeT LSE_MODE_,
-    bool HAS_SOFTCAP_>
+    bool HAS_SOFTCAP_,
+    bool RETURN_SOFTMAX_>
 class BlockEpilogue<
-    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>,
+    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_, RETURN_SOFTMAX_>,
     OutputType_,
     InputType_,
     MaskType_>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>;
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_, RETURN_SOFTMAX_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
     using ElementOutput = typename OutputType_::Element;
     using ElementInput = typename InputType_::Element;
@@ -67,7 +68,8 @@ public:
     ~BlockEpilogue() {}
 
     __aicore__ inline
-    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_)
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_, 
+        AscendC::GlobalTensor<ElementOutput> gPret_, uint64_t stridePret_, uint32_t maxKvSeqlen_)
     {
         // Allocate UB space
         constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
@@ -87,6 +89,13 @@ public:
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
+
+        if constexpr (RETURN_SOFTMAX_) {
+            gPret = gPret_;
+            stridePret = stridePret_;
+            maxKvSeqlen = maxKvSeqlen_;
+        }
+
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
@@ -101,11 +110,13 @@ public:
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
     }
-
-    template <typename T>
-    __aicore__ inline T Min(T a, T b)
+    
+    __aicore__ inline
+    void set_gmOffsetPret(uint64_t gmOffsetPret_)
     {
-        return (a > b) ? b : a;
+        if constexpr (RETURN_SOFTMAX_) {
+            gmOffsetPret = gmOffsetPret_;
+        }
     }
 
     __aicore__ inline
@@ -813,6 +824,27 @@ public:
                 rowNumCurLoop, columnNumRound / BLOCK_SIZE, 0, (columnNumPad - columnNumRound) / BLOCK_SIZE));
     }
 
+    __aicore__ inline
+    void CopyPretUbToGm(
+        uint32_t sUbOffset, uint64_t qNOffset, uint32_t qSIdxCurBlock, uint32_t qSOffset, uint32_t rowNum,
+        uint32_t columnNum, uint32_t columnNumRound, uint32_t qSBlockSize)
+    {
+        uint32_t rowsDone = 0;
+        while (rowsDone < rowNum) {
+            uint32_t rowsCurHead = Min(rowNum - rowsDone, qSBlockSize - qSIdxCurBlock);
+            AscendC::DataCopyPad(
+                gPret[gmOffsetPret + qNOffset + qSOffset], lpUbTensor[sUbOffset][rowsDone * columnNumRound],
+                AscendC::DataCopyExtParams(
+                    rowsCurHead, columnNum * sizeof(ElementOutput),
+                    (columnNumRound - columnNum) * sizeof(ElementOutput) / 32,
+                    (maxKvSeqlen - columnNum) * sizeof(ElementOutput), 0));
+            rowsDone += rowsCurHead;
+            qNOffset += stridePret;
+            qSIdxCurBlock = 0;
+            qSOffset = 0;
+        }
+    }
+
     template <bool doTriUMask>
     __aicore__ inline
     void SubCoreCompute(
@@ -820,7 +852,8 @@ public:
         uint32_t rowOffset, uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
         uint32_t isFirstRowLoop, uint32_t isLastRowLoop,
         uint32_t columnNumRound, uint32_t pingpongFlag,
-        uint32_t curStackTileMod, bool isSplitKV, bool startsWithMaskThenNomaskFlag = false)
+        uint32_t curStackTileMod, uint32_t rowOffsetIoGm, uint32_t qSBlockSize,
+        bool isSplitKV, bool startsWithMaskThenNomaskFlag = false)
     {
         uint32_t rowNumCurLoop = layoutOutput.shape(0);
         uint32_t rowNumCurLoopRound = RoundUp(rowNumCurLoop, FLOAT_BLOCK_SIZE);
@@ -859,6 +892,15 @@ public:
 
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
         CopyPUbToGm(gOutput, sUbOffset, rowNumCurLoop, columnNumRound, columnNumPad);
+
+        if constexpr (RETURN_SOFTMAX_) {
+            uint64_t qNOffset = static_cast<uint64_t>(rowOffsetIoGm / qSBlockSize) * stridePret;
+            uint32_t qSIdxCurBlock = rowOffsetIoGm % qSBlockSize;
+            uint32_t qSOffset = qSIdxCurBlock * maxKvSeqlen;
+            CopyPretUbToGm(
+                sUbOffset, qNOffset, qSIdxCurBlock, qSOffset, rowNumCurLoop, columnNum, columnNumRound, qSBlockSize);
+        }
+
         if constexpr (!doTriUMask) {
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
             if (isLastNoMaskStackTile && isLastRowLoop) {
@@ -948,6 +990,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     isSplitKV,
                     startsWithMaskThenNomaskFlag);
             }
@@ -1088,6 +1132,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     isSplitKV);
                 // next loop mask load (after P copy releases shared UB via EVENT_ID0)
                 if (rowLoopIdx < rowLoopNum) {
@@ -1306,6 +1352,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     false,
                     false);
                 // next loop mask load (after P copy releases shared UB via EVENT_ID0)
@@ -1342,6 +1390,11 @@ public:
 private:
     float scaleValue;
     float softcapValue;
+    uint64_t gmOffsetPret;
+    uint64_t stridePret;
+    uint32_t maxKvSeqlen;
+    AscendC::GlobalTensor<ElementOutput> gPret;
+
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;

--- a/csrc/ascend910/flash_attn_npu/tilingdata.h
+++ b/csrc/ascend910/flash_attn_npu/tilingdata.h
@@ -63,6 +63,7 @@ struct FAInferTilingData {
     uint32_t needCoreNum;
     coreNode coreInfo[25];
     splitNode splitInfo[25];
+    __gm__ uint8_t* pDevice = nullptr;
 
     uint32_t get_numHeads() const { return numHeads; }
     uint32_t get_embeddingSize() const { return embeddingSize; }
@@ -93,6 +94,7 @@ struct FAInferTilingData {
     uint64_t get_splitOTotalSize() const { return splitOTotalSize; }
     uint32_t get_totalSplitNodeNum() const { return totalSplitNodeNum; }
     uint32_t get_needCoreNum() const { return needCoreNum; }
+    __gm__ uint8_t* get_pDevice() const { return pDevice; }
 
     void set_numHeads(uint32_t value) { numHeads = value; }
     void set_embeddingSize(uint32_t value) { embeddingSize = value; }
@@ -123,6 +125,7 @@ struct FAInferTilingData {
     void set_splitOTotalSize(uint64_t value) { splitOTotalSize = value; }
     void set_totalSplitNodeNum(uint32_t value) { totalSplitNodeNum = value; }
     void set_needCoreNum(uint32_t value) { needCoreNum = value; }
+    void set_pDevice(__gm__ uint8_t* value) { pDevice = value; }
 };
 
 #endif


### PR DESCRIPTION
## Related Issue

Closes #123 



## Summary

Support `return_attn_probs` parameter in `flash_attn_npu` v2.

- Add `RETURN_SOFTMAX` template parameter (also used in dropout).
- Support `return_attn_probs` in both standard and varlen forward functions.



## Validation

According to the FA v2 interface, `return_attn_probs` is enabled only when `p_dropout > 0`. Since dropout is not implemented yet, we temporarily removed this constraint and modified the test scripts to verify this functionality:

<img width="1104" height="466" alt="图片" src="https://github.com/user-attachments/assets/aeb705ec-4f22-42b4-b0c2-5e679b7c1d42" />
<img width="1321" height="296" alt="图片" src="https://github.com/user-attachments/assets/9f64e503-2222-4d30-bf3d-daf04c061c63" />


All tests passed for both standard and varlen forward functions.

<img width="1374" height="358" alt="图片" src="https://github.com/user-attachments/assets/980c9027-45b0-4b71-b766-0cfca404b291" />




## Additional Information

None.