### PR TITLE
fix(fa): size rescale UB tiles with aligned head stride

### DIFF
--- a/csrc/ascend910/flash_attn_npu/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu/flash_api.cpp
@@ -527,9 +527,10 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
         (max_kv_seqlen >= static_cast<int32_t>(blockDim) * 512);
     bool isShortSeq = (static_cast<double>(numTasks) <= 0.4 * blockDim) &&
         (max_kv_seqlen >= 1024);
+    bool flashDecodeDimSupported = head_size_og <= 128;
     bool flashDecodeFlag = paged_KV &&
         (seqlen_q * groupSize <= 128) && (seqlen_q <= 16) &&
-        (max_kv_seqlen >= 1024) && (seqlen_q > 0) && (isLongSeq || isShortSeq);
+        (max_kv_seqlen >= 1024) && (seqlen_q > 0) && (isLongSeq || isShortSeq) && flashDecodeDimSupported;
 
     SplitContext splitCtx;
     splitCtx.batch_size = batch_size;

--- a/csrc/ascend910/flash_attn_npu/rescale_o.hpp
+++ b/csrc/ascend910/flash_attn_npu/rescale_o.hpp
@@ -666,7 +666,8 @@ public:
     {
         uint32_t rowNum = actualBlockShape.m();
         uint32_t embed = actualBlockShape.n();
-        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embed;
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
         uint32_t rowNumTile = RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
 
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();

--- a/csrc/ascend910/flash_attn_npu_3/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu_3/flash_api.cpp
@@ -371,9 +371,10 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
             (maxKVSeqlenCalc >= 1024);
         TORCH_CHECK(num_splits <= 1 || (paged_KV && is_varlen_q),
                     "NPU FlashAttention num_splits>1 currently requires paged KV cache and varlen-q (TND) layout");
+        bool flashDecodeDimSupported = head_size_og <= 128;
         flashDecodeFlag = paged_KV && is_varlen_q &&
             (maxQSeqlenCalc * groupSize <= 128) && (maxQSeqlenCalc <= 16) &&
-            (maxKVSeqlenCalc >= 1024) && (minQSeqlenCalc > 0) && (isLongSeq || isShortSeq);
+            (maxKVSeqlenCalc >= 1024) && (minQSeqlenCalc > 0) && (isLongSeq || isShortSeq) && flashDecodeDimSupported;
         tiling_cpu_ptr->set_flashDecodeFlag(flashDecodeFlag ? 1U : 0U);
         tiling_cpu_ptr->set_numSplits(num_splits > 0 ? static_cast<uint32_t>(num_splits) : 1U);
 

--- a/csrc/ascend910/flash_attn_npu_3/rescale_o.hpp
+++ b/csrc/ascend910/flash_attn_npu_3/rescale_o.hpp
@@ -666,7 +666,8 @@ public:
     {
         uint32_t rowNum = actualBlockShape.m();
         uint32_t embed = actualBlockShape.n();
-        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embed;
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
         uint32_t rowNumTile = RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
 
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();

--- a/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
@@ -288,9 +288,10 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
             (maxKVSeqlenCalc >= 1024);
         TORCH_CHECK(num_splits <= 1 || (paged_KV && is_varlen_q),
                     "NPU FlashAttention num_splits>1 currently requires paged KV cache and varlen-q (TND) layout");
+        bool flashDecodeDimSupported = head_size_og <= 128;
         flashDecodeFlag = paged_KV && is_varlen_q &&
             (maxQSeqlenCalc * groupSize <= 128) && (maxQSeqlenCalc <= 16) &&
-            (maxKVSeqlenCalc >= 1024) && (minQSeqlenCalc > 0) && (isLongSeq || isShortSeq);
+            (maxKVSeqlenCalc >= 1024) && (minQSeqlenCalc > 0) && (isLongSeq || isShortSeq) && flashDecodeDimSupported;
         tiling_cpu_ptr->set_flashDecodeFlag(flashDecodeFlag ? 1U : 0U);
         tiling_cpu_ptr->set_numSplits(num_splits > 0 ? static_cast<uint32_t>(num_splits) : 1U);
 

--- a/csrc/ascend910/flash_attn_npu_4/rescale_o.hpp
+++ b/csrc/ascend910/flash_attn_npu_4/rescale_o.hpp
@@ -669,7 +669,8 @@ public:
     {
         uint32_t rowNum = actualBlockShape.m();
         uint32_t embed = actualBlockShape.n();
-        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embed;
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
         uint32_t rowNumTile = RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
 
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -434,6 +434,21 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
 
 
 test_cases = [
+    (torch.bfloat16, 4, 32, 2, 6, 512, 201, 0, 128, False, -1, -1, 30.0),
+    (torch.bfloat16, 2, 40, 2, 6, 512, 240, 0, 128, False, -1, -1, 30.0),
+    (torch.bfloat16, 1, 1, 1, 256, 512, 200, 1, 128, True, 512, 0, 30.0),
+    (torch.bfloat16, 1, 1, 1, 256, 512, 200, 1, 128, True, 512, 256, 30.0),
+    (torch.bfloat16, 5, 4, 4, 256, 512, 240, 0, 128, True, -128, 864, 30.0),
+    (torch.bfloat16, 1, 1, 1, 256, 512, 200, 1, 128, False, 0, 256, 30.0),
+    (torch.float16, 2, 2, 2, 512, 512, 200, 0, 128, False, 64, 128, 30.0),
+    (torch.bfloat16, 1, 3, 1, 128, 512, 240, 1, 128, False, -1, -1, 30.0),
+    (torch.bfloat16, 1, 3, 1, 128, 512, 200, 0, 128, False, -1, -1, 30.0),
+]
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_custom_ops_with_headdim_lt_192(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap):
+    test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, window_size_left, window_size_right, softcap)
+
+test_cases = [
     # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap)
     (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
     (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -547,6 +547,25 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         torch.testing.assert_close(softmax_lse.cpu(), golden_lseL.cpu(), rtol=rtol, atol=atol)
 
 test_cases = [
+    (torch.bfloat16, 4, 8, 8, 32, 128, 201, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 32, 8, 1, 512, 195, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 4, 16, 512, 200, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 4, 32, 256, 235, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 32, 8, 1, 256, 197, 128, False, "BSND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 8, 32, 256, 200, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 32, 8, 32, 256, 200, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 8, 64, 256, 200, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 8, 32, 8, 64, 256, 200, 128, True, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 4, 32, 8, 48, 256, 200, 128, False, "TND", False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 16, 2, 15, 2048, 200, 128, True, "TND", False, -1, -1, 0.0),
+]
+@pytest.mark.parametrize("num_splits", [0, 1, 2])
+@pytest.mark.parametrize("cache_mode", [0, 1])
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal, layout, is_varied, window_size_left, window_size_right, softcap", test_cases)
+def test_fa_custom_ops_with_headdim_lt_192(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, num_splits, window_size_left, window_size_right, softcap):
+    test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, num_splits, window_size_left, window_size_right, softcap)
+
+test_cases = [
     # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap)
     (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
     (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),

--- a/tests/test_flash_attn_npu_v4.py
+++ b/tests/test_flash_attn_npu_v4.py
@@ -618,3 +618,22 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     _, r_plain_cann = compare_rule(golden_out.cpu().float(), out_out.cpu().float())
     assert r_plain_cann, "Golden vs CANN check FAILED"
     print("--- end ---")
+
+test_cases = [
+    (torch.bfloat16, 4, 8, 8, 32, 128, 201, 128, False, "BSND", False, -1, -1),
+    (torch.bfloat16, 8, 32, 8, 1, 512, 195, 128, False, "BSND", False, -1, -1),
+    (torch.bfloat16, 4, 32, 4, 16, 512, 200, 128, False, "BSND", False, -1, -1),
+    (torch.bfloat16, 4, 32, 4, 32, 256, 235, 128, False, "BSND", False, -1, -1),
+    (torch.bfloat16, 2, 32, 8, 1, 256, 197, 128, False, "BSND", False, -1, -1),
+    (torch.bfloat16, 4, 32, 8, 32, 256, 200, 128, False, "TND", False, -1, -1),
+    (torch.bfloat16, 8, 32, 8, 32, 256, 200, 128, False, "TND", False, -1, -1),
+    (torch.bfloat16, 4, 32, 8, 64, 256, 200, 128, False, "TND", False, -1, -1),
+    (torch.bfloat16, 8, 32, 8, 64, 256, 200, 128, True, "TND", False, -1, -1),
+    (torch.bfloat16, 4, 32, 8, 48, 256, 200, 128, False, "TND", False, -1, -1),
+    (torch.bfloat16, 2, 16, 2, 15, 2048, 200, 128, True, "TND", False, -1, -1, 0.0),
+]
+@pytest.mark.parametrize("num_splits", [0, 1, 2])
+@pytest.mark.parametrize("cache_mode", [0, 1])
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal, layout, is_varied, window_size_left, window_size_right", test_cases)
+def test_fa_custom_ops_with_headdim_lt_192(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, window_size_left, window_size_right, num_splits):
+    test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, window_size_left, window_size_right, num_splits)


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->
Fixes #135 


## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

`rescale_o.hpp` calculates the number of rows per UB tile using the logical head dimension:


## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->

<img width="1975" height="285" alt="image" src="https://github.com/user-attachments/assets/e2a14c6a-eb85-4e94-8c6e-806b233ee756" />


## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->
NA