### PR TITLE
fix ci: isolate per-run log dir and container cleanup

### DIFF
--- a/.github/workflows/npu_ci.yml
+++ b/.github/workflows/npu_ci.yml
@@ -240,6 +240,10 @@ jobs:
       CI_REQUIRE_HEALTHY_NPU: ${{ matrix.require_healthy }}
       CI_NPU_MAX_TASKS: ${{ matrix.max_tasks }}
       TARGET_SHA: ${{ needs.prepare.outputs.sha }}
+      # 每个 run 独立的宿主机日志目录 + 容器 label, 避免与本机并行的其它 run (如 NPU CI Full)
+      # 共用 /tmp/ci_test_logs 导致日志混淆, 也避免 cleanup 误杀其它 run 的容器。
+      CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ matrix.arch_label }}
+      CI_RUN_LABEL: ${{ github.run_id }}-${{ matrix.arch_label }}
     outputs:
       run_outcome: ${{ steps.run.outcome }}
     steps:
@@ -360,14 +364,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.arch_label }}
-          path: /tmp/ci_test_logs/
+          path: ${{ env.CI_TEST_LOG_DIR_HOST }}/
           retention-days: 7
 
       - name: Kill orphaned CI containers
         if: always()
         run: |
-          echo "cleaning up orphaned containers from image: $CI_DOCKER_IMAGE"
-          orphans=$(docker ps -q --filter "ancestor=$CI_DOCKER_IMAGE")
+          echo "cleaning up orphaned containers for run: $CI_RUN_LABEL"
+          orphans=$(docker ps -q --filter "label=ci_run_id=$CI_RUN_LABEL")
           if [ -n "$orphans" ]; then
             echo "killing orphaned containers: $orphans"
             docker kill $orphans 2>/dev/null || true

--- a/.github/workflows/npu_ci_full.yml
+++ b/.github/workflows/npu_ci_full.yml
@@ -76,6 +76,10 @@ jobs:
       CI_TEST_WORKERS: ${{ github.event.inputs.workers }}
       CI_MODE: full
       CI_REF: ${{ github.event.inputs.ref }}
+      # 每个 run 独立的宿主机日志目录 + 容器 label, 避免与本机并行的其它 run (如 NPU CI)
+      # 共用 /tmp/ci_test_logs 导致日志混淆, 也避免 cleanup 误杀其它 run 的容器。
+      CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ matrix.arch_label }}
+      CI_RUN_LABEL: ${{ github.run_id }}-${{ matrix.arch_label }}
     steps:
       - name: Check arch match
         id: arch
@@ -142,14 +146,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.arch_label }}
-          path: /tmp/ci_test_logs/
+          path: ${{ env.CI_TEST_LOG_DIR_HOST }}/
           retention-days: 7
 
       - name: Kill orphaned CI containers
         if: always()
         run: |
-          echo "cleaning up orphaned containers from image: $CI_DOCKER_IMAGE"
-          orphans=$(docker ps -q --filter "ancestor=$CI_DOCKER_IMAGE")
+          echo "cleaning up orphaned containers for run: $CI_RUN_LABEL"
+          orphans=$(docker ps -q --filter "label=ci_run_id=$CI_RUN_LABEL")
           if [ -n "$orphans" ]; then
             echo "killing orphaned containers: $orphans"
             docker kill $orphans 2>/dev/null || true

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -34,6 +34,11 @@ CI_SKIP_BUILD="${CI_SKIP_BUILD:-false}"
 # 宿主机日志目录: 挂载进容器, 容器内写的日志直接落到宿主机, 避免 --rm 删除容器后日志丢失。
 # 同时让 workflow 的 upload-artifact (path: /tmp/ci_test_logs) 能读到日志。
 CI_TEST_LOG_DIR_HOST="${CI_TEST_LOG_DIR_HOST:-/tmp/ci_test_logs}"
+# 本 run 的唯一标识, 用作 docker 容器 label:
+#   1. 多个 workflow (NPU CI / NPU CI Full) 共用同一镜像, 不能按镜像名清理容器;
+#      必须按本 run 自己的 label 清理, 避免误杀并行的其它 run 的容器。
+#   2. 不同 run 写各自独立的宿主机日志目录, 避免日志互相覆盖/混用。
+CI_RUN_LABEL="${CI_RUN_LABEL:-$(basename "$CI_TEST_LOG_DIR_HOST")}"
 
 log() { printf '[CI] %s\n' "$*"; }
 die() { printf '[CI][ERROR] %s\n' "$*" >&2; exit 1; }
@@ -84,6 +89,7 @@ run_build_phase() {
   log "=== Phase 1: build (no NPU lock) ==="
   docker run --rm \
     "${privileged_args[@]}" \
+    --label "ci_run_id=$CI_RUN_LABEL" \
     --network host \
     --ipc host \
     -v "$REPO_ROOT:/workspace/flash-attention-npu" \
@@ -116,6 +122,7 @@ run_docker_test() {
   chmod 777 "$CI_TEST_LOG_DIR_HOST" 2>/dev/null || true
   docker run --rm \
     "${privileged_args[@]}" \
+    --label "ci_run_id=$CI_RUN_LABEL" \
     --network host \
     --ipc host \
     -v "$REPO_ROOT:/workspace/flash-attention-npu" \


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->
Refs #102 


## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->



## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->
Running NPU CI and NPU CI Full in parallel on the same self-hosted
910B runner shared two resources, causing cross-run interference:

- Both workflows mounted the same host log dir (/tmp/ci_test_logs) and
  uploaded artifacts from it, so logs from the two runs overwrote each
  other and the wrong run's logs were downloaded.
- Both "Kill orphaned CI containers" steps (if: always()) filtered by
  `ancestor=$CI_DOCKER_IMAGE`. Since both use the same 910B image, a
  failing run killed every container from that image, including the
  other still-running workflow, forcing it to stop.