### PR TITLE
feat: impl dropout and return_attn_probs in FA v2

### DIFF
--- a/csrc/ascend910/flash_attn_npu/fa_block.h
+++ b/csrc/ascend910/flash_attn_npu/fa_block.h
@@ -15,19 +15,22 @@ using namespace Catlass;
 
 namespace Catlass::Epilogue {
     enum class LseModeT {NONE = 0, OUT_ONLY = 1};
-    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_>
+    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_SOFTCAP_, bool RETURN_SOFTMAX_, bool HAS_DROPOUT_>
     struct EpilogueAtlasA2OnlineSoftmaxT {
         using ArchTag = Arch::AtlasA2;
         using IntermPrec = SM_DTYPE_;
         static constexpr LseModeT LSE_MODE = LSE_MODE_;
         static constexpr bool HAS_SOFTCAP = HAS_SOFTCAP_;
+        static constexpr bool RETURN_SOFTMAX = RETURN_SOFTMAX_;
+        static constexpr bool HAS_DROPOUT = HAS_DROPOUT_;
     };
 
-    template <LseModeT LSE_MODE_, typename SM_DTYPE_>
+    template <LseModeT LSE_MODE_, typename SM_DTYPE_, bool HAS_DROPOUT_>
     struct EpilogueAtlasA2RescaleOT {
         using ArchTag = Arch::AtlasA2;
         using IntermPrec = SM_DTYPE_;
         static constexpr LseModeT LSE_MODE = LSE_MODE_;
+        static constexpr bool HAS_DROPOUT = HAS_DROPOUT_;
     };
 
     template <LseModeT LSE_MODE_>

--- a/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
@@ -575,7 +575,7 @@ public:
 
     CATLASS_DEVICE
     void SubGrapA(int64_t curIdx, int64_t curS1Idx, int64_t curS2Idx, DBParams& dbParam,
-                                event_t mte2WaitMte3A)
+                                event_t mte2WaitMte3A, event_t dropMte2WaitV)
     {
         pingpongIdx = dbParam.taskId % 2;
         s2Extend = (curS2Idx == s2VecLoop - 1) ? (dbParam.s2CvExtend - (s2VecLoop - 1) * s2VecSize) : s2VecSize;
@@ -709,40 +709,39 @@ public:
             int64_t dropMaskOffset = GetDropMaskOffset(dbParam, curS1Idx, s2VBegin, dropMaskS2Stride);
             LocalTensor<uint8_t> dropMaskU8 =
                 unifiedBuffer.GetWithOffset<uint8_t>(8 * 1024 / sizeof(uint8_t), ubBufferOffset + U8Begin);
-            event_t v2Mte2A = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE2));
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(v2Mte2A);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(v2Mte2A);
             AscendC::DataCopyExtParams dropCopyParams;
             dropCopyParams.blockCount = static_cast<uint16_t>(s1ExtendSubGraph);
             dropCopyParams.blockLen = maskRowBytes;
             dropCopyParams.srcStride = dropMaskS2Stride - maskRowBytes;
             dropCopyParams.dstStride = 0;
             dropCopyParams.rsv = 0;
-            AscendC::DataCopyPad(dropMaskU8, dropMaskGm[dropMaskOffset], dropCopyParams,
-                                 {false, 0, 0, 0});
-            event_t dropMte2WaitV = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(dropMte2WaitV);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(dropMte2WaitV);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(dropMte2WaitV);
+            AscendC::DataCopyPad(dropMaskU8, dropMaskGm[dropMaskOffset], dropCopyParams, {false, 0, 0, 0});
+
+            event_t dropVWaitMte2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(dropVWaitMte2);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(dropVWaitMte2);
             // The pre-dropout P in simpleSoftmaxResBuf (DbBegin) is left
             // untouched for SubGrapB.
             vecDropBuffer = unifiedBuffer.GetWithOffset<T2>(TMP_UB_SIZE / sizeof(T2), TMP_UB_OFFSET);
-            AscendC::Muls(vecDropBuffer, simpleSoftmaxResBuf,
-                          static_cast<float>(1.0f / keepProb), s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::Muls(
+                vecDropBuffer, simpleSoftmaxResBuf, static_cast<float>(1.0f / keepProb),
+                s1ExtendSubGraph * s2ExtendAlign);
             AscendC::PipeBarrier<PIPE_V>();
             if (s2Extend == 256) {
-                AscendC::Select(vecDropBuffer, dropMaskU8, vecDropBuffer, static_cast<T2>(0.0f),
-                                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
-                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Select(
+                    vecDropBuffer, dropMaskU8, vecDropBuffer, static_cast<T2>(0.0f),
+                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
             } else {
                 for (uint32_t r = 0; r < s1ExtendSubGraph; r++) {
-                    AscendC::Select(vecDropBuffer[r * s2ExtendAlign],
-                                    dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
-                                    vecDropBuffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
-                                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
-                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Select(
+                        vecDropBuffer[r * s2ExtendAlign], dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
+                        vecDropBuffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
+                        AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
                 }
             }
         }
+
         LocalTensor<T1> vecCopyOutBuffer = vecDropBuffer.template ReinterpretCast<T1>();
         if constexpr (!AscendC::IsSameType<T1, float>::value) {
             vecCopyOutBuffer = unifiedBuffer.GetWithOffset<T1>(17 * 1024 / sizeof(T1), ubBufferOffset + T1Begin);
@@ -771,7 +770,8 @@ public:
 
     CATLASS_DEVICE
     void SubGrapB(int64_t curIdx, int64_t s1VecLoop, int64_t s2VecLoop,
-                                 int64_t curS1Idx, int64_t curS2Idx, DBParams& dbParam, event_t mte2WaitMte3B)
+                                 int64_t curS1Idx, int64_t curS2Idx, DBParams& dbParam, 
+                                 event_t mte2WaitMte3B, event_t dropMte2WaitV)
     {
         pingpongIdx = dbParam.taskId % 2;
         uint32_t ubBufferOffset = DbBegin;
@@ -791,9 +791,9 @@ public:
             AscendC::DataCopy(savedS, srcS, s1ExtendSubGraph * s2ExtendAlign);
         }
 
+        LocalTensor<float> sfmgClc3 = unifiedBuffer.GetWithOffset<float>(SFMG_UB_SIZE / sizeof(float), SFMG_UB_OFFSET);
         if (preS1Idx != curS1Idx) {
             preS1Idx = curS1Idx;
-            LocalTensor<float> sfmgClc3 = unifiedBuffer.GetWithOffset<float>(SFMG_UB_SIZE / sizeof(float), SFMG_UB_OFFSET);
             AscendC::DataCopy(sfmgClc3, sfmgWorkspaceGm[sfmgOffset + curS1Idx * s1VecSize * 8], s1ExtendSubGraph * 8);
         }
 
@@ -816,28 +816,26 @@ public:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(vWaitMte2);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(vWaitMte2);
 
-        AscendC::PipeBarrier<PIPE_V>();
         if constexpr (IS_DROP == ENABLE) {
             if (s2Extend == 256) {
-                AscendC::Select(vecClc1Buffer, dropMaskU8, vecClc1Buffer, static_cast<T2>(0.0f),
-                                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
-                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Select(
+                    vecClc1Buffer, dropMaskU8, vecClc1Buffer, static_cast<T2>(0.0f),
+                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
             } else {
                 for (uint32_t r = 0; r < s1ExtendSubGraph; r++) {
-                    AscendC::Select(vecClc1Buffer[r * s2ExtendAlign],
-                                    dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
-                                    vecClc1Buffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
-                                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
-                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Select(
+                        vecClc1Buffer[r * s2ExtendAlign], dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
+                        vecClc1Buffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
+                        AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
                 }
             }
-            AscendC::Muls(vecClc1Buffer, vecClc1Buffer, static_cast<float>(1.0f / keepProb),
-                          s1ExtendSubGraph * s2ExtendAlign);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(dropMte2WaitV);
             AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Muls(
+                vecClc1Buffer, vecClc1Buffer, static_cast<float>(1.0f / keepProb), s1ExtendSubGraph * s2ExtendAlign);
         }
-        uint32_t sub_block_cout = (s2ExtendAlign + cal_repeat_num - 1) / cal_repeat_num;
-        LocalTensor<float> sfmgClc3 = unifiedBuffer.GetWithOffset<float>(SFMG_UB_SIZE / sizeof(float), SFMG_UB_OFFSET);
 
+        uint32_t sub_block_cout = (s2ExtendAlign + cal_repeat_num - 1) / cal_repeat_num;
         AscendC::PipeBarrier<PIPE_V>();
         for (uint32_t subIdx = 0; subIdx < sub_block_cout; subIdx++) {
             uint32_t subMaskCout =
@@ -963,11 +961,16 @@ public:
 
             event_t mte2WaitMte3A = static_cast<event_t>(GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_MTE2>());
             event_t mte2WaitMte3B = static_cast<event_t>(GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_MTE2>());
-            SubGrapA(loopCnt, curS1Idx, curS2Idx, dbParam, mte2WaitMte3A);
-            SubGrapB(loopCnt, s1VecLoop, s2VecLoop, curS1Idx, curS2Idx, dbParam, mte2WaitMte3B);
+            event_t dropMte2WaitV = static_cast<event_t>(GetTPipePtr()->AllocEventID<AscendC::HardEvent::V_MTE2>());
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(dropMte2WaitV);
 
+            SubGrapA(loopCnt, curS1Idx, curS2Idx, dbParam, mte2WaitMte3A, dropMte2WaitV);
+            SubGrapB(loopCnt, s1VecLoop, s2VecLoop, curS1Idx, curS2Idx, dbParam, mte2WaitMte3B, dropMte2WaitV);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(dropMte2WaitV);
             GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_MTE2>(mte2WaitMte3A);
             GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_MTE2>(mte2WaitMte3B);
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::V_MTE2>(dropMte2WaitV);
         }
     }
 };

--- a/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
@@ -191,7 +191,8 @@ public:
     constexpr static int64_t GM_DOUBLE_BUFFER = 2;
     constexpr static int64_t SOFTCAP_UB_OFFSET = 32 * 1024;
     constexpr static int64_t TMP_UB_OFFSET = 148 * 1024;
-    constexpr static int64_t SFMG_UB_OFFSET = (148 + 33) * 1024;
+    // Dropout Select UB conflict with original SFMG, move to 140KB
+    constexpr static int64_t SFMG_UB_OFFSET = 140 * 1024;
     constexpr static int64_t TMP_UB_SIZE = 33 * 1024;
     constexpr static int64_t SFMG_UB_SIZE = 8 * 1024;
     constexpr static int64_t TOTAL_SIZE = 189 * 1024;
@@ -1024,7 +1025,8 @@ public:
     constexpr static uint32_t DbBegin = 74 * 1024;
     constexpr static int64_t SOFTCAP_UB_OFFSET = 32 * 1024;
     constexpr static int64_t TMP_UB_OFFSET = 148 * 1024;
-    constexpr static int64_t SFMG_UB_OFFSET = (148 + 33) * 1024;
+    // Dropout Select UB (last 8 KB) conflict with original SFMG, move SFMG UB to 140KB
+    constexpr static int64_t SFMG_UB_OFFSET = 140 * 1024;
     constexpr static int64_t TMP_UB_SIZE = 33 * 1024;
     constexpr static int64_t SFMG_UB_SIZE = 8 * 1024;
     constexpr static int64_t TOTAL_SIZE = 189 * 1024;

--- a/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_epilogue_op.hpp
@@ -69,7 +69,7 @@ public:
     uint32_t vecBlockNum;
 
     GlobalTensor<T1> keyGm, valueGm, dxGm, queryGm, forwardResGm;
-    GlobalTensor<uint8_t> maskWorkSpaceGm, attenMaskU8Gm, dropMaskGm;
+    GlobalTensor<uint8_t> attenMaskU8Gm, dropMaskGm;
     GlobalTensor<float> softmaxLseGm;
 
     GlobalTensor<float> dqWorkSpaceGm, dkWorkSpaceGm, dvWorkSpaceGm, sfmgWorkspaceGm;
@@ -112,7 +112,6 @@ public:
     int64_t s2Token;
     int64_t actualCalcS1Token;
     int64_t actualCalcS2Token;
-    bool dropBitMode;
 
     int64_t b;
     int64_t n2;
@@ -176,6 +175,7 @@ public:
     constexpr static uint32_t T2BlockBegin = 58 * 1024;
     constexpr static uint32_t U8Begin = 66 * 1024;
     constexpr static uint32_t DbBegin = 74 * 1024;
+    constexpr static uint32_t DROP_MASK_UB_ROW_STRIDE = 32;
 
     constexpr static uint32_t DTYPE_FACTOR = sizeof(T2) / sizeof(T1);
     constexpr static uint32_t cal_block_num = 32 / sizeof(T2);
@@ -288,10 +288,8 @@ public:
 
         actual_seq_qlen_addr = actual_seq_qlen;
         actual_seq_kvlen_addr = actual_seq_kvlen;
-        dropBitMode = tilingData->dropoutIsDivisibleBy8 != 0;
         if constexpr (IS_DROP == ENABLE) {
-            __gm__ uint8_t *dropMaskAddr = dropBitMode ? drop_mask : workspace + tilingData->dropBeginAddr;
-            dropMaskGm.SetGlobalBuffer((__gm__ uint8_t *)dropMaskAddr);
+            dropMaskGm.SetGlobalBuffer((__gm__ uint8_t *)drop_mask);
         }
         keepProb = tilingData->keepProb;
         scaleValue = tilingData->scaleValue;
@@ -300,13 +298,6 @@ public:
 
         int64_t sfmgOutputSize = b * n2 * g * s1 * 8;
         if constexpr (INPUT_LAYOUT == TND) {
-            int64_t seqS2Len = 0;
-            seqS2Len = ((__gm__ int32_t *)actual_seq_kvlen)[0];
-            dropBitMode = (seqS2Len % 8 == 0);
-            for (int64_t i = 0; i + 1 < b; i++) {
-                seqS2Len = ((__gm__ int32_t *)actual_seq_kvlen)[i + 1] - ((__gm__ int32_t *)actual_seq_kvlen)[i];
-                dropBitMode = (dropBitMode && (seqS2Len % 8 == 0));
-            }
             sfmgOutputSize = ((__gm__ int32_t*)actual_seq_qlen)[b - 1] * n2 * g * 8;
         }
 
@@ -567,33 +558,18 @@ public:
     }
 
     CATLASS_DEVICE
-    void DropOutCopy(LocalTensor<uint8_t> &vecInDropBuffer, int64_t curS1Idx, int64_t s2VBegin)
-    {
-    }
-
-        CATLASS_DEVICE
     int64_t GetDropMaskOffset(const DBParams &dbParam, int64_t curS1Idx, uint32_t s2VBegin, uint32_t dropMaskS2Stride)
     {
+        // Drop mask layout: bit-packed (bit 1 = keep), ceil(max_seqlen_k/8)
+        // bytes per row, rows indexed per (batch, head) block padded to
+        // max_seqlen_q rows (s1 = max_seqlen_q; s1Pos is the row within the
+        // batch for both BSND and TND). s2VBegin is always a multiple of 8
+        // (s2CvInner/s2VecSize are 16-aligned, s2CvExtend is 8-aligned).
         int64_t qHeadNumLocal = n2 * g;
         int64_t headIdx = dbParam.n2Idx * g + dbParam.gIdx;
         int64_t s1Pos = dbParam.s1oIdx * s1CvInner + curS1Idx * s1VecSize;
-        if constexpr (INPUT_LAYOUT == TND) {
-            int64_t batchS1S2Prefix = 0;
-            for (int64_t bi = 0; bi < dbParam.bIdx; ++bi) {
-                int32_t as1 = (bi == 0) ? ((__gm__ int32_t *)actual_seq_qlen_addr)[0] :
-                    ((__gm__ int32_t *)actual_seq_qlen_addr)[bi] -
-                    ((__gm__ int32_t *)actual_seq_qlen_addr)[bi - 1];
-                int32_t as2 = (bi == 0) ? ((__gm__ int32_t *)actual_seq_kvlen_addr)[0] :
-                    ((__gm__ int32_t *)actual_seq_kvlen_addr)[bi] -
-                    ((__gm__ int32_t *)actual_seq_kvlen_addr)[bi - 1];
-                batchS1S2Prefix += as1 * as2;
-            }
-            return batchS1S2Prefix * qHeadNumLocal +
-                headIdx * dbParam.actualS1Len * static_cast<int64_t>(dropMaskS2Stride) +
-                s1Pos * static_cast<int64_t>(dropMaskS2Stride) + static_cast<int64_t>(s2VBegin);
-        }
         return ((dbParam.bIdx * qHeadNumLocal + headIdx) * s1 + s1Pos) *
-            static_cast<int64_t>(dropMaskS2Stride) + static_cast<int64_t>(s2VBegin);
+            static_cast<int64_t>(dropMaskS2Stride) + static_cast<int64_t>(s2VBegin / 8);
     }
 
     CATLASS_DEVICE
@@ -647,9 +623,6 @@ public:
                 CopyInAttenMaskBool(attenMaskUbuint8, attenMaskOffsetPre, s1ExtendSubGraph, s2Extend);
             }
         }
-
-        LocalTensor<uint8_t> vecInDropBuffer =
-            unifiedBuffer.GetWithOffset<uint8_t>(8 * 1024 / sizeof(uint8_t), ubBufferOffset + U8Begin);
 
         LocalTensor<float> vecClc2Buffer =
             unifiedBuffer.GetWithOffset<float>(32 * 1024 / sizeof(float), ubBufferOffset + T2Begin);
@@ -721,34 +694,27 @@ public:
         LocalTensor<T2> vecDropBuffer = simpleSoftmaxResBuf;
 
         if constexpr (IS_DROP == ENABLE) {
-            uint32_t totalElems = s1ExtendSubGraph * s2ExtendAlign;
-            uint32_t maskRowStride = (s2ExtendAlign + 31) / 32 * 32;
-            uint32_t dropMaskS2Stride;
-            if constexpr (INPUT_LAYOUT == TND) {
-                dropMaskS2Stride = static_cast<uint32_t>(dbParam.actualS2Len);
-            } else {
-                dropMaskS2Stride = dropBitMode ? (static_cast<uint32_t>(s2) + 31) / 32 * 32 :
-                    static_cast<uint32_t>(s2);
-            }
+            // Read the bit-packed dropout mask into U8Begin. The mask stays in
+            // UB (U8Begin) for SubGrapB of the same iteration.
+            //
+            // The transfer granularity is a 32B block:
+            // rows with blockLen < 32B land in per-row r*32B slots, so every
+            // Select mask row start is 32B aligned (mirror of the forward's
+            // CopyDropMaskToUb / ApplyDropoutStd). When s2Extend == 256 the
+            // rows fill the 32B slots contiguously, allowing a single
+            // full-tile Select; smaller rows go through the per-row loop.
+            uint32_t maskRowBytes = CeilDiv(s2Extend, 8);
+            uint32_t dropMaskS2Stride = CeilDiv(s2, 8);
             int64_t dropMaskOffset = GetDropMaskOffset(dbParam, curS1Idx, s2VBegin, dropMaskS2Stride);
             LocalTensor<uint8_t> dropMaskU8 =
                 unifiedBuffer.GetWithOffset<uint8_t>(8 * 1024 / sizeof(uint8_t), ubBufferOffset + U8Begin);
-            LocalTensor<uint16_t> dropMaskU16 = dropMaskU8.template ReinterpretCast<uint16_t>();
-            AscendC::Duplicate<uint16_t>(dropMaskU16, static_cast<uint16_t>(0),
-                                         s1ExtendSubGraph * maskRowStride / 2);
             event_t v2Mte2A = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE2));
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(v2Mte2A);
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(v2Mte2A);
             AscendC::DataCopyExtParams dropCopyParams;
             dropCopyParams.blockCount = static_cast<uint16_t>(s1ExtendSubGraph);
-            uint32_t dropReadLen = s2Extend;
-            if constexpr (INPUT_LAYOUT == TND) {
-                if (s2Extend > dropMaskS2Stride) {
-                    dropReadLen = dropMaskS2Stride;
-                }
-            }
-            dropCopyParams.blockLen = static_cast<uint32_t>(dropReadLen * sizeof(uint8_t));
-            dropCopyParams.srcStride = static_cast<uint32_t>((dropMaskS2Stride - dropReadLen) * sizeof(uint8_t));
+            dropCopyParams.blockLen = maskRowBytes;
+            dropCopyParams.srcStride = dropMaskS2Stride - maskRowBytes;
             dropCopyParams.dstStride = 0;
             dropCopyParams.rsv = 0;
             AscendC::DataCopyPad(dropMaskU8, dropMaskGm[dropMaskOffset], dropCopyParams,
@@ -756,22 +722,25 @@ public:
             event_t dropMte2WaitV = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(dropMte2WaitV);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(dropMte2WaitV);
+            // The pre-dropout P in simpleSoftmaxResBuf (DbBegin) is left
+            // untouched for SubGrapB.
             vecDropBuffer = unifiedBuffer.GetWithOffset<T2>(TMP_UB_SIZE / sizeof(T2), TMP_UB_OFFSET);
             AscendC::Muls(vecDropBuffer, simpleSoftmaxResBuf,
-                          static_cast<float>(1.0f / keepProb), totalElems);
+                          static_cast<float>(1.0f / keepProb), s1ExtendSubGraph * s2ExtendAlign);
             AscendC::PipeBarrier<PIPE_V>();
-            LocalTensor<uint8_t> selScratch = unifiedBuffer.GetWithOffset<uint8_t>(
-                17 * 1024 / sizeof(uint8_t), ubBufferOffset + T1Begin);
-            AscendC::SelectWithBytesMaskShapeInfo selInfo;
-            selInfo.firstAxis = s1ExtendSubGraph;
-            selInfo.srcLastAxis = s2ExtendAlign;
-            selInfo.maskLastAxis = maskRowStride;
-            vecDropBuffer.SetSize(s1ExtendSubGraph * s2ExtendAlign);
-            dropMaskU8.SetSize(s1ExtendSubGraph * maskRowStride);
-            AscendC::SelectWithBytesMask(vecDropBuffer,
-                                         static_cast<float>(0.0f), vecDropBuffer,
-                                         dropMaskU8, selScratch, selInfo);
-            AscendC::PipeBarrier<PIPE_V>();
+            if (s2Extend == 256) {
+                AscendC::Select(vecDropBuffer, dropMaskU8, vecDropBuffer, static_cast<T2>(0.0f),
+                                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
+                AscendC::PipeBarrier<PIPE_V>();
+            } else {
+                for (uint32_t r = 0; r < s1ExtendSubGraph; r++) {
+                    AscendC::Select(vecDropBuffer[r * s2ExtendAlign],
+                                    dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
+                                    vecDropBuffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
+                                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+            }
         }
         LocalTensor<T1> vecCopyOutBuffer = vecDropBuffer.template ReinterpretCast<T1>();
         if constexpr (!AscendC::IsSameType<T1, float>::value) {
@@ -827,44 +796,11 @@ public:
             AscendC::DataCopy(sfmgClc3, sfmgWorkspaceGm[sfmgOffset + curS1Idx * s1VecSize * 8], s1ExtendSubGraph * 8);
         }
 
-        LocalTensor<uint8_t> vecInDropBuffer =
-            unifiedBuffer.GetWithOffset<uint8_t>(8 * 1024 / sizeof(uint8_t), ubBufferOffset + U8Begin);
+        LocalTensor<uint8_t> dropMaskU8 =
+            unifiedBuffer.GetWithOffset<uint8_t>(8 * 1024 / sizeof(uint8_t), U8Begin);
 
         LocalTensor<T2> vecClc1Buffer = unifiedBuffer.GetWithOffset<T2>(33 * 1024 / sizeof(T2), ubBufferOffset + T1Begin);
         LocalTensor<T2> dyvBuffer = unifiedBuffer.GetWithOffset<T2>(33 * 1024 / sizeof(T2), TMP_UB_OFFSET);
-        uint32_t maskRowStrideB = (s2ExtendAlign + 31) / 32 * 32;
-        if constexpr (IS_DROP == ENABLE) {
-            LocalTensor<uint16_t> vecInDropBufferU16 = vecInDropBuffer.template ReinterpretCast<uint16_t>();
-            AscendC::Duplicate<uint16_t>(vecInDropBufferU16, static_cast<uint16_t>(0),
-                                         s1ExtendSubGraph * maskRowStrideB / 2);
-            AscendC::PipeBarrier<PIPE_V>();
-            int64_t s2VBegin = dbParam.s2oIdx * s2CvInner + curS2Idx * s2VecSize;
-            uint32_t dropMaskS2StrideB;
-            if constexpr (INPUT_LAYOUT == TND) {
-                dropMaskS2StrideB = static_cast<uint32_t>(dbParam.actualS2Len);
-            } else {
-                dropMaskS2StrideB = dropBitMode ? (static_cast<uint32_t>(s2) + 31) / 32 * 32 :
-                    static_cast<uint32_t>(s2);
-            }
-            int64_t dropMaskOffsetB = GetDropMaskOffset(dbParam, curS1Idx, s2VBegin, dropMaskS2StrideB);
-            event_t v2Mte2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE2));
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(v2Mte2);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(v2Mte2);
-            AscendC::DataCopyExtParams dropCopyParams;
-            dropCopyParams.blockCount = static_cast<uint16_t>(s1ExtendSubGraph);
-            uint32_t dropReadLenB = s2Extend;
-            if constexpr (INPUT_LAYOUT == TND) {
-                if (s2Extend > dropMaskS2StrideB) {
-                    dropReadLenB = dropMaskS2StrideB;
-                }
-            }
-            dropCopyParams.blockLen = static_cast<uint32_t>(dropReadLenB * sizeof(uint8_t));
-            dropCopyParams.srcStride = static_cast<uint32_t>((dropMaskS2StrideB - dropReadLenB) * sizeof(uint8_t));
-            dropCopyParams.dstStride = 0;
-            dropCopyParams.rsv = 0;
-            AscendC::DataCopyPad(vecInDropBuffer, dropMaskGm[dropMaskOffsetB], dropCopyParams,
-                                 {false, 0, 0, 0});
-        }
         if (s2VecLoop == 1) {
             AscendC::DataCopy(vecClc1Buffer, mm1WorkspaceGm[pingpongIdx * cubeBaseMN + curS1Idx * s1VecSize * s2ExtendAlign],
                         s1ExtendSubGraph * s2ExtendAlign);
@@ -881,20 +817,21 @@ public:
 
         AscendC::PipeBarrier<PIPE_V>();
         if constexpr (IS_DROP == ENABLE) {
-            uint32_t totalElems = s1ExtendSubGraph * s2ExtendAlign;
-            AscendC::Muls(vecClc1Buffer, vecClc1Buffer, static_cast<float>(1.0f / keepProb), totalElems);
-            AscendC::PipeBarrier<PIPE_V>();
-            LocalTensor<uint8_t> selScratchB = unifiedBuffer.GetWithOffset<uint8_t>(
-                TMP_UB_SIZE / sizeof(uint8_t), TMP_UB_OFFSET);
-            AscendC::SelectWithBytesMaskShapeInfo selInfoB;
-            selInfoB.firstAxis = s1ExtendSubGraph;
-            selInfoB.srcLastAxis = s2ExtendAlign;
-            selInfoB.maskLastAxis = maskRowStrideB;
-            vecClc1Buffer.SetSize(s1ExtendSubGraph * s2ExtendAlign);
-            vecInDropBuffer.SetSize(s1ExtendSubGraph * maskRowStrideB);
-            AscendC::SelectWithBytesMask(vecClc1Buffer,
-                                         static_cast<float>(0.0f), vecClc1Buffer,
-                                         vecInDropBuffer, selScratchB, selInfoB);
+            if (s2Extend == 256) {
+                AscendC::Select(vecClc1Buffer, dropMaskU8, vecClc1Buffer, static_cast<T2>(0.0f),
+                                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s1ExtendSubGraph * s2ExtendAlign);
+                AscendC::PipeBarrier<PIPE_V>();
+            } else {
+                for (uint32_t r = 0; r < s1ExtendSubGraph; r++) {
+                    AscendC::Select(vecClc1Buffer[r * s2ExtendAlign],
+                                    dropMaskU8[r * DROP_MASK_UB_ROW_STRIDE],
+                                    vecClc1Buffer[r * s2ExtendAlign], static_cast<T2>(0.0f),
+                                    AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, s2ExtendAlign);
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+            }
+            AscendC::Muls(vecClc1Buffer, vecClc1Buffer, static_cast<float>(1.0f / keepProb),
+                          s1ExtendSubGraph * s2ExtendAlign);
             AscendC::PipeBarrier<PIPE_V>();
         }
         uint32_t sub_block_cout = (s2ExtendAlign + cal_repeat_num - 1) / cal_repeat_num;

--- a/csrc/ascend910/flash_attn_npu/fag_epilogue_pre.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_epilogue_pre.hpp
@@ -32,18 +32,6 @@ public:
 
     AscendC::TPipe *pipe;
     AscendC::GlobalTensor<float> dqWorkSpaceGm, dkWorkSpaceGm, dvWorkSpaceGm;
-    AscendC::GlobalTensor<uint8_t> drop_maskGm, maskWorkSpaceGm;
-    AscendC::TQue<AscendC::QuePosition::VECIN, 1> helpQue;
-    AscendC::TQue<AscendC::QuePosition::VECIN, 1> inputQue;
-    AscendC::TQue<AscendC::QuePosition::VECIN, 1> castQue;
-    AscendC::TQue<AscendC::QuePosition::VECOUT, 1> outQue;
-
-    constexpr static uint32_t HELP_LEN = 256;
-    constexpr static uint32_t BIT8 = 8;
-    constexpr static uint32_t NUMBER_8 = 8;
-    constexpr static uint32_t B16_VECTOR_MASK = 128;
-    constexpr static uint32_t BOOL_BLOCK_NUMS = 32;
-    constexpr static uint32_t SINGLE_UB_PROCESS_NUM = 30 * 1024;
 
     uint32_t cBlockIdx;
     uint32_t qPreBlockFactor;
@@ -57,17 +45,6 @@ public:
     int64_t dqOffset;
     int64_t initdkSize;
     int64_t dkvOffset;
-    int64_t dropMaskSize;
-    int64_t maskSingleCoreNum;
-    uint32_t maskUsedCoreNum;
-    uint32_t maskUBProcessNum;
-    uint32_t maskTailUBProcessNum;
-    uint32_t maskUBLoop;
-    bool isDropBoolMode;
-
-    AscendC::DataCopyParams copyParams;
-    AscendC::BinaryRepeatParams repParams;
-    half padValue{1.0};
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource, AscendC::TPipe *pipe_in, __gm__ uint8_t *dq,
@@ -75,13 +52,7 @@ public:
     {
         cBlockIdx = AscendC::GetBlockIdx();
         pipe = pipe_in;
-        isDropBoolMode = false;
-        dropMaskSize = 0;
-        maskSingleCoreNum = 0;
-        maskUsedCoreNum = 0;
-        maskUBProcessNum = 0;
-        maskTailUBProcessNum = 0;
-        maskUBLoop = 0;
+        (void)drop_mask;
 
         __gm__ TilingData *tilingData = reinterpret_cast<__gm__ TilingData *>(tiling_in);
         int64_t dqWorkSpaceOffset = tilingData->dqWorkSpaceOffset;
@@ -110,39 +81,6 @@ public:
         dqOffset = ((int64_t)cBlockIdx) * qPreBlockFactor;
         initdkSize = cBlockIdx == kvPreBlockTotal - 1 ? kvPreBlockTail : kvPreBlockFactor;
         dkvOffset = ((int64_t)cBlockIdx) * kvPreBlockFactor;
-
-        if constexpr (!std::is_same_v<TilingData, FAGv2TilingData>) {
-            isDropBoolMode = drop_mask != nullptr && tilingData->dropoutIsDivisibleBy8 == 0;
-            if (isDropBoolMode) {
-                drop_maskGm.SetGlobalBuffer((__gm__ uint8_t *)drop_mask);
-                maskWorkSpaceGm.SetGlobalBuffer((__gm__ uint8_t *)workspace + tilingData->dropBeginAddr);
-
-                constexpr uint32_t inputBufferLen = 4 * 1024;
-                constexpr uint32_t castBufferLen = 60 * 1024;
-                constexpr uint32_t outputBufferLen = 30 * 1024;
-                pipe->InitBuffer(helpQue, 1, HELP_LEN);
-                pipe->InitBuffer(inputQue, 1, inputBufferLen);
-                pipe->InitBuffer(castQue, 1, castBufferLen);
-                pipe->InitBuffer(outQue, 1, outputBufferLen);
-
-                dropMaskSize = tilingData->dropMaskSize;
-                int64_t maskSize = (dropMaskSize + BOOL_BLOCK_NUMS - 1) / BOOL_BLOCK_NUMS * BOOL_BLOCK_NUMS;
-                maskSingleCoreNum = ((maskSize + tilingData->blockOuter - 1) / tilingData->blockOuter
-                                    + BOOL_BLOCK_NUMS - 1) / BOOL_BLOCK_NUMS * BOOL_BLOCK_NUMS;
-                maskUsedCoreNum = tilingData->maskCoreNum;
-
-                repParams.src0BlkStride = 1;
-                repParams.src0RepStride = 0;
-                repParams.src1BlkStride = 0;
-                repParams.src1RepStride = 0;
-                repParams.dstBlkStride = 1;
-                repParams.dstRepStride = NUMBER_8;
-
-                copyParams.blockCount = 1;
-                copyParams.srcStride = 0;
-                copyParams.dstStride = 0;
-            }
-        }
     }
 
     CATLASS_DEVICE
@@ -160,62 +98,6 @@ public:
         if (g_coreType == AscendC::AIV && cBlockIdx < kvPreBlockTotal) {
             AscendC::InitOutput<float>(dkWorkSpaceGm[dkvOffset], initdkSize, 0);
             AscendC::InitOutput<float>(dvWorkSpaceGm[dkvOffset], initdkSize, 0);
-        }
-
-        if (g_coreType == AscendC::AIV && cBlockIdx < maskUsedCoreNum) {
-            if (!isDropBoolMode) {
-                return;
-            }
-            maskUBLoop = maskSingleCoreNum == 0 ? 0 :
-                (maskSingleCoreNum + SINGLE_UB_PROCESS_NUM - 1) / SINGLE_UB_PROCESS_NUM;
-            maskTailUBProcessNum = maskSingleCoreNum - (maskUBLoop - 1) * SINGLE_UB_PROCESS_NUM;
-            if (unlikely(cBlockIdx == maskUsedCoreNum - 1)) {
-                int64_t maskSize = (dropMaskSize + BOOL_BLOCK_NUMS - 1) / BOOL_BLOCK_NUMS * BOOL_BLOCK_NUMS;
-                int64_t tailCoreNum = maskSize - (static_cast<int64_t>(maskUsedCoreNum) - 1) * maskSingleCoreNum;
-                tailCoreNum = (tailCoreNum + BOOL_BLOCK_NUMS - 1) / BOOL_BLOCK_NUMS * BOOL_BLOCK_NUMS;
-                maskUBLoop = (tailCoreNum + SINGLE_UB_PROCESS_NUM - 1) / SINGLE_UB_PROCESS_NUM;
-                maskTailUBProcessNum = tailCoreNum - (maskUBLoop - 1) * SINGLE_UB_PROCESS_NUM;
-            }
-
-            auto helpTensor = helpQue.AllocTensor<half>();
-            AscendC::Duplicate<half>(helpTensor, padValue, HELP_LEN / sizeof(half));
-            AscendC::PipeBarrier<PIPE_V>();
-
-            int64_t outputAddr = static_cast<int64_t>(cBlockIdx) * maskSingleCoreNum;
-            int64_t inputAddr = outputAddr / BIT8;
-
-            for (int64_t idx = 0; idx < maskUBLoop; idx++) {
-                maskUBProcessNum = SINGLE_UB_PROCESS_NUM;
-                int64_t outputOffset = idx * maskUBProcessNum;
-                int64_t inputOffset = outputOffset / BIT8;
-                if (unlikely(idx == maskUBLoop - 1)) {
-                    maskUBProcessNum = maskTailUBProcessNum;
-                }
-
-                auto inputTensor = inputQue.AllocTensor<uint8_t>();
-                copyParams.blockLen = maskUBProcessNum / BIT8;
-                AscendC::DataCopyPad(inputTensor, drop_maskGm[inputAddr + inputOffset], copyParams, {false, 0, 0, 0});
-                inputQue.EnQue(inputTensor);
-                inputQue.DeQue<uint8_t>();
-
-                auto castTensor = castQue.AllocTensor<half>();
-                uint8_t selectRepeat = (maskUBProcessNum + B16_VECTOR_MASK - 1) / B16_VECTOR_MASK;
-                AscendC::Select(castTensor, inputTensor, helpTensor, static_cast<half>(0.0),
-                                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, B16_VECTOR_MASK, selectRepeat, repParams);
-                AscendC::PipeBarrier<PIPE_V>();
-                inputQue.FreeTensor(inputTensor);
-
-                auto outputTensor = outQue.AllocTensor<uint8_t>();
-                AscendC::Cast(outputTensor, castTensor, AscendC::RoundMode::CAST_ROUND, maskUBProcessNum);
-                castQue.FreeTensor(castTensor);
-
-                outQue.EnQue(outputTensor);
-                outQue.DeQue<uint8_t>();
-                copyParams.blockLen = maskUBProcessNum;
-                AscendC::DataCopyPad(maskWorkSpaceGm[outputAddr + outputOffset], outputTensor, copyParams);
-                outQue.FreeTensor(outputTensor);
-            }
-            helpQue.FreeTensor(helpTensor);
         }
     }
 };

--- a/csrc/ascend910/flash_attn_npu/fag_general_dispatch.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_general_dispatch.hpp
@@ -33,6 +33,8 @@ struct FagGeneralLaunchArgs {
     bool is_causal;
     bool deterministic;
     bool is_softcap;
+    bool has_dropout = false;
+    uint8_t *dropMaskDevice = nullptr;
     uint32_t qk_headdim_kernel; // 64 / 128 / 192 / 256
     uint8_t *dOutDevice;
     uint8_t *qDevice;

--- a/csrc/ascend910/flash_attn_npu/fag_general_dispatch_impl.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_general_dispatch_impl.hpp
@@ -7,15 +7,15 @@
 // Shared implementation of the v2 FAGGeneral backward dispatch. Included by the
 // generated autogen/fag_general_dispatch_<dtype>_<layout>.cpp stubs, each of
 // which explicitly instantiates one launch_fag_general_dispatch_{bf16,fp16}<TND>
-// or <BSND>, so the 64 FAGGeneral instantiations land in four parallel-compiled
-// object files (16 each) instead of one.
+// or <BSND>, so the 256 FAGGeneral instantiations land in four parallel-compiled
+// object files (64 each) instead of one.
 //
 // The launch tree reproduces the exact causal x deterministic x headdim
 // combinations of LaunchFAGGeneralKernel in fag_general_launch.hpp; the dtype
 // dimension is hoisted to a template parameter so each TU instantiates one
 // dtype. Template params of ::FAGGeneral map as:
-//   <DTemplateType::AlignedNNN, DType, kInputLayout, IS_CAUSAL, 0, IS_DTM>
-// where IS_CAUSAL => IS_ATTEN_MASK, IS_DTM => deterministic (IS_DTM).
+//   <DTemplateType::AlignedNNN, DType, kInputLayout, IS_CAUSAL, IS_DROP, IS_DTM, IS_SOFTCAP>
+// where IS_CAUSAL => IS_ATTEN_MASK, IS_DROP => dropout, IS_DTM => deterministic.
 //
 // ADAPTATION vs opt_compiler: main wraps the FAGGeneral launch in an
 // at_npu::native::OpCommand::RunOpApiV2("ascendc_fag", ...) context (for aicpu
@@ -55,16 +55,18 @@
 // the FAGTilingData type. Each dtype TU includes it once.
 #include "../flash_attn_npu_3/fag_kernel.cpp"
 
-// Launch one FAGGeneral specialization. IS_CAUSAL / IS_DTM map to the kernel's
-// IS_ATTEN_MASK / IS_DTM template params; ALN selects DTemplateType::AlignedNNN.
-// Argument order is identical to LaunchFAGGeneralKernel in fag_general_launch.hpp.
-#define GEN_LAUNCH(ALN, IS_CAUSAL, IS_DTM, IS_SOFTCAP)                                       \
-    ::FAGGeneral<DTemplateType::ALN, DType, kInputLayout, IS_CAUSAL, 0, IS_DTM, IS_SOFTCAP>  \
-        <<<a.blockDim, nullptr, a.aclStream>>>(                                              \
-            a.fftsAddr, a.dOutDevice, a.qDevice, a.kDevice, a.vDevice,                       \
-            a.outDevice, nullptr, a.attenMaskDevice, a.softMaxLseDevice,                     \
-            a.cuSeqQlenDevice, a.cuSeqKvlenDevice, a.dqDevice, a.dkDevice,                   \
-            a.dvDevice, nullptr, a.workspaceDevice, a.tilingDevice)
+// Launch one FAGGeneral specialization. IS_CAUSAL / IS_DROP / IS_DTM map to the
+// kernel's IS_ATTEN_MASK / IS_DROP / IS_DTM template params; ALN selects
+// DTemplateType::AlignedNNN. Argument order is identical to
+// LaunchFAGGeneralKernel in fag_general_launch.hpp; the drop_mask kernel arg is
+// a.dropMaskDevice (nullptr when dropout is off).
+#define GEN_LAUNCH(ALN, IS_CAUSAL, IS_DROP, IS_DTM, IS_SOFTCAP)                             \
+    ::FAGGeneral<DTemplateType::ALN, DType, kInputLayout, IS_CAUSAL, IS_DROP, IS_DTM,       \
+                 IS_SOFTCAP> <<<a.blockDim, nullptr, a.aclStream>>>(                        \
+        a.fftsAddr, a.dOutDevice, a.qDevice, a.kDevice, a.vDevice, a.outDevice,             \
+        a.dropMaskDevice, a.attenMaskDevice, a.softMaxLseDevice, a.cuSeqQlenDevice,         \
+        a.cuSeqKvlenDevice, a.dqDevice, a.dkDevice, a.dvDevice, nullptr, a.workspaceDevice, \
+        a.tilingDevice)
 
 template <typename DType, uint32_t kInputLayout>
 void launch_fag_general_dispatch_impl(const FagGeneralLaunchArgs &a) {
@@ -73,83 +75,163 @@ void launch_fag_general_dispatch_impl(const FagGeneralLaunchArgs &a) {
     auto fag_general_call = [=]() -> int {
         const uint32_t hd = a.qk_headdim_kernel;
         if (a.is_softcap) {
-            if (a.is_causal) {
-                if (a.deterministic) {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  1, 1, 1); break;
-                        case 128: GEN_LAUNCH(Aligned128, 1, 1, 1); break;
-                        case 192: GEN_LAUNCH(Aligned192, 1, 1, 1); break;
-                        case 256: GEN_LAUNCH(Aligned256, 1, 1, 1); break;
-                        default: break;
+            if (a.has_dropout) {
+                if (a.is_causal) {
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 1, 1, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 1, 1, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 1, 1, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 1, 1, 1); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 1, 0, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 1, 0, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 1, 0, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 1, 0, 1); break;
+                            default: break;
+                        }
                     }
                 } else {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  1, 0, 1); break;
-                        case 128: GEN_LAUNCH(Aligned128, 1, 0, 1); break;
-                        case 192: GEN_LAUNCH(Aligned192, 1, 0, 1); break;
-                        case 256: GEN_LAUNCH(Aligned256, 1, 0, 1); break;
-                        default: break;
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 1, 1, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 1, 1, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 1, 1, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 1, 1, 1); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 1, 0, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 1, 0, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 1, 0, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 1, 0, 1); break;
+                            default: break;
+                        }
                     }
                 }
             } else {
-                if (a.deterministic) {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  0, 1, 1); break;
-                        case 128: GEN_LAUNCH(Aligned128, 0, 1, 1); break;
-                        case 192: GEN_LAUNCH(Aligned192, 0, 1, 1); break;
-                        case 256: GEN_LAUNCH(Aligned256, 0, 1, 1); break;
-                        default: break;
+                if (a.is_causal) {
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 0, 1, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 0, 1, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 0, 1, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 0, 1, 1); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 0, 0, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 0, 0, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 0, 0, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 0, 0, 1); break;
+                            default: break;
+                        }
                     }
                 } else {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  0, 0, 1); break;
-                        case 128: GEN_LAUNCH(Aligned128, 0, 0, 1); break;
-                        case 192: GEN_LAUNCH(Aligned192, 0, 0, 1); break;
-                        case 256: GEN_LAUNCH(Aligned256, 0, 0, 1); break;
-                        default: break;
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 0, 1, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 0, 1, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 0, 1, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 0, 1, 1); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 0, 0, 1); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 0, 0, 1); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 0, 0, 1); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 0, 0, 1); break;
+                            default: break;
+                        }
                     }
                 }
             }
         } else {
-            if (a.is_causal) {
-                if (a.deterministic) {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  1, 1, 0); break;
-                        case 128: GEN_LAUNCH(Aligned128, 1, 1, 0); break;
-                        case 192: GEN_LAUNCH(Aligned192, 1, 1, 0); break;
-                        case 256: GEN_LAUNCH(Aligned256, 1, 1, 0); break;
-                        default: break;
+            if (a.has_dropout) {
+                if (a.is_causal) {
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 1, 1, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 1, 1, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 1, 1, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 1, 1, 0); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 1, 0, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 1, 0, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 1, 0, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 1, 0, 0); break;
+                            default: break;
+                        }
                     }
                 } else {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  1, 0, 0); break;
-                        case 128: GEN_LAUNCH(Aligned128, 1, 0, 0); break;
-                        case 192: GEN_LAUNCH(Aligned192, 1, 0, 0); break;
-                        case 256: GEN_LAUNCH(Aligned256, 1, 0, 0); break;
-                        default: break;
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 1, 1, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 1, 1, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 1, 1, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 1, 1, 0); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 1, 0, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 1, 0, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 1, 0, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 1, 0, 0); break;
+                            default: break;
+                        }
                     }
                 }
             } else {
-                if (a.deterministic) {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  0, 1, 0); break;
-                        case 128: GEN_LAUNCH(Aligned128, 0, 1, 0); break;
-                        case 192: GEN_LAUNCH(Aligned192, 0, 1, 0); break;
-                        case 256: GEN_LAUNCH(Aligned256, 0, 1, 0); break;
-                        default: break;
+                if (a.is_causal) {
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 0, 1, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 0, 1, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 0, 1, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 0, 1, 0); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  1, 0, 0, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 1, 0, 0, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 1, 0, 0, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 1, 0, 0, 0); break;
+                            default: break;
+                        }
                     }
                 } else {
-                    switch (hd) {
-                        case 64:  GEN_LAUNCH(Aligned64,  0, 0, 0); break;
-                        case 128: GEN_LAUNCH(Aligned128, 0, 0, 0); break;
-                        case 192: GEN_LAUNCH(Aligned192, 0, 0, 0); break;
-                        case 256: GEN_LAUNCH(Aligned256, 0, 0, 0); break;
-                        default: break;
+                    if (a.deterministic) {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 0, 1, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 0, 1, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 0, 1, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 0, 1, 0); break;
+                            default: break;
+                        }
+                    } else {
+                        switch (hd) {
+                            case 64:  GEN_LAUNCH(Aligned64,  0, 0, 0, 0); break;
+                            case 128: GEN_LAUNCH(Aligned128, 0, 0, 0, 0); break;
+                            case 192: GEN_LAUNCH(Aligned192, 0, 0, 0, 0); break;
+                            case 256: GEN_LAUNCH(Aligned256, 0, 0, 0, 0); break;
+                            default: break;
+                        }
                     }
                 }
             }
-        } 
-        
+        }
+
         return 0;
     };
     at_npu::native::OpCommand::RunOpApiV2("ascendc_fag", fag_general_call);

--- a/csrc/ascend910/flash_attn_npu/fag_general_host.cpp
+++ b/csrc/ascend910/flash_attn_npu/fag_general_host.cpp
@@ -34,7 +34,9 @@ std::vector<at::Tensor> launch_fag_general(
     bool is_causal,
     int64_t window_size_left,
     int64_t window_size_right,
-    bool deterministic)
+    bool deterministic,
+    float p_dropout,
+    const std::optional<at::Tensor> &rng_state)
 {
     const c10::OptionalDeviceGuard device_guard(device_of(q));
     auto aclStream = c10_npu::getCurrentNPUStream().stream(false);
@@ -77,7 +79,8 @@ std::vector<at::Tensor> launch_fag_general(
     }
     fagInfo.softcapValue = softcap;
 
-    fagInfo.keepProb = 1.0f;
+    bool has_dropout = (p_dropout > 0.0f);
+    fagInfo.keepProb = 1.0f - p_dropout;
     if (window_size_left >= max_seqlen_k - 1) {
         window_size_left = -1;
     }
@@ -194,6 +197,26 @@ std::vector<at::Tensor> launch_fag_general(
         cuSeqKvlenDevice = static_cast<uint8_t *>(const_cast<void *>(seqlenk_gpu_tensor.data_ptr()));
     }
 
+    // Regenerate the dropout bit-mask from the forward's rng_state (seed,
+    // offset). Same aclnnDropoutGenMask call and the same bit layout as the
+    // forward (batch x heads x max_seqlen_q rows x ceil(max_seqlen_k/8) bytes
+    // per row, bit 1 = keep), so the backward applies the exact same mask
+    // element-wise as the forward.
+    at::Tensor drop_mask_npu_tensor;
+    if (has_dropout) {
+        TORCH_CHECK(rng_state.has_value(),
+                    "launch_fag_general: rng_state must be provided when p_dropout > 0.");
+        const at::Tensor &rng_state_tensor = rng_state.value();
+        TORCH_CHECK(rng_state_tensor.is_cpu() && rng_state_tensor.numel() == 2,
+                    "launch_fag_general: rng_state must be a CPU tensor of 2 int64 (seed, offset).");
+        const uint64_t *rng_state_ptr = reinterpret_cast<const uint64_t *>(rng_state_tensor.data_ptr());
+        int64_t drop_mask_bit_num =
+            static_cast<int64_t>(batch_size) * nheads * max_seqlen_q * ((max_seqlen_k + 7) / 8 * 8);
+        drop_mask_npu_tensor = at_npu::native::npu_dropout_gen_mask(
+            torch::empty({0}, at::device(at::kPrivateUse1).dtype(at::kFloat)), {drop_mask_bit_num}, p_dropout,
+            rng_state_ptr[0], rng_state_ptr[1], false, false);
+    }
+
     // FAGGeneral backward kernel launches live in
     // fag_general_dispatch_<dtype>_<layout>.cpp. gen_args.is_causal carries
     // main's has_attn_mask flag (causal OR local), which selects the kernel's
@@ -205,6 +228,9 @@ std::vector<at::Tensor> launch_fag_general(
     gen_args.fftsAddr = fftsAddr;
     gen_args.is_causal = has_attn_mask;
     gen_args.is_softcap = has_softcap;
+    gen_args.has_dropout = has_dropout;
+    gen_args.dropMaskDevice =
+        has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr;
     gen_args.deterministic = deterministic;
     gen_args.qk_headdim_kernel = qk_headdim_kernel;
     gen_args.dOutDevice = dOutDevice;

--- a/csrc/ascend910/flash_attn_npu/fag_general_host.hpp
+++ b/csrc/ascend910/flash_attn_npu/fag_general_host.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include "torch_npu/csrc/core/npu/NPUStream.h"
 #include "torch_npu/csrc/framework/OpCommand.h"
+#include "third_party/op-plugin/op_plugin/include/ops.h"
 
 // Launch general-purpose FAG (FlashAttentionGrad) kernel (BSND or TND).
 std::vector<at::Tensor> launch_fag_general(
@@ -27,6 +28,8 @@ std::vector<at::Tensor> launch_fag_general(
     bool is_causal,
     int64_t window_size_left,
     int64_t window_size_right,
-    bool deterministic);
+    bool deterministic,
+    float p_dropout,
+    const std::optional<at::Tensor> &rng_state);
 
 #endif

--- a/csrc/ascend910/flash_attn_npu/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu/flash_api.cpp
@@ -20,6 +20,8 @@
 #include "fag_tiling.cpp"
 #include "fag_general_host.hpp"
 #include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/aten/NPUGeneratorImpl.h"
+#include "third_party/op-plugin/op_plugin/include/ops.h"
 #include "torch_npu/csrc/core/npu/NPUCachingAllocator.h"
 #include "torch_npu/csrc/framework/OpCommand.h"
 #include "runtime/rt_ffts.h"
@@ -136,6 +138,48 @@ static at::Tensor GetSchedulerMetadataImpl(FAMetadataArgs args,
         c10_npu::NPUCachingAllocator::recordStream(cuSeqlensQ->storage().data_ptr(), aicpuStream);
     }
     return meta;
+}
+
+// async copy dropout tiling data
+static void PatchTilingDropoutFields(const at::Tensor &schedMd, uint64_t tilingOffset,
+                                     float dropoutValue, uint8_t *pDevice,
+                                     uint8_t *dropMaskDevice)
+{
+    if (dropMaskDevice == nullptr) {
+        return;
+    }
+    struct DropFields {
+        float dropoutValue;
+        uint64_t pDevice;
+        uint64_t dropMaskDevice;
+    };
+    // The Host2Device staging copy is async and reads the source after this function
+    // returns; static + same-stream serialization keeps it alive and safe.
+    static at::Tensor patchDev;
+    static DropFields fields;
+    if (!patchDev.defined()) {
+        patchDev = torch::empty({static_cast<int64_t>(sizeof(DropFields))},
+                                at::device(at::kPrivateUse1).dtype(at::kByte));
+    }
+    fields.dropoutValue = dropoutValue;
+    fields.pDevice = reinterpret_cast<uint64_t>(pDevice);
+    fields.dropMaskDevice = reinterpret_cast<uint64_t>(dropMaskDevice);
+
+    at::Tensor patchCpu = torch::from_blob(&fields, {static_cast<int64_t>(sizeof(DropFields))},
+                                           at::TensorOptions().dtype(torch::kUInt8));
+    patchDev.copy_(patchCpu);  // H2D staging, current stream
+
+    auto tilingView = schedMd.narrow(0, static_cast<int64_t>(tilingOffset),
+                                     static_cast<int64_t>(sizeof(FAInferTilingData)));
+    tilingView.narrow(0, offsetof(FAInferTilingData, dropoutValue), 4)
+        .view(torch::kFloat32)
+        .copy_(patchDev.narrow(0, offsetof(DropFields, dropoutValue), 4).view(torch::kFloat32));
+    tilingView.narrow(0, offsetof(FAInferTilingData, pDevice), 8)
+        .view(torch::kInt64)
+        .copy_(patchDev.narrow(0, offsetof(DropFields, pDevice), 8).view(torch::kInt64));
+    tilingView.narrow(0, offsetof(FAInferTilingData, dropMaskDevice), 8)
+        .view(torch::kInt64)
+        .copy_(patchDev.narrow(0, offsetof(DropFields, dropMaskDevice), 8).view(torch::kInt64));
 }
 
 std::vector<at::Tensor>
@@ -508,6 +552,7 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
         std::optional<at::Tensor> scheduler_metadata_)
 {
     const c10::OptionalDeviceGuard device_guard(device_of(q));
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(false);
     auto q_dtype = q.dtype();
     bool is_bf16 = q.dtype() == torch::kBFloat16;
     // parameters checking
@@ -515,12 +560,11 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
                 "FlashAttention only support fp16 and bf16 data type");
     TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
     TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
+    TORCH_CHECK(p_dropout >= 0.0f && p_dropout < 1.0f, "p_dropout must be in [0.0, 1.0)");
 
     // block unsupported params
     TORCH_CHECK(!alibi_slopes_.has_value(), "NPU FlashAttention does not support alibi_slopes.");
-    TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
-    TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
-    TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
 
     TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
@@ -564,9 +608,10 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     auto opts = q.options().device(at::kPrivateUse1);
     auto p = torch::empty({0}, opts);
     if (return_softmax) {
-        p = torch::empty({batch_size, num_heads, seqlen_q, seqlen_k}, opts);
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::zeros({batch_size, num_heads, seqlen_q, seqlen_k}, opts);
     }
-    auto rng_state = torch::empty({2}, opts.dtype(torch::kInt64));
+    auto rng_state = torch::empty({2}, at::device(c10::kCPU).dtype(torch::kInt64));
 
     // init mask / tiling: host computes them unless the AICPU already did
     // (scheduler-metadata path).
@@ -577,6 +622,23 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     at::Tensor workspace_tensor;
     uint32_t blockDim = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAic();
     bool has_softcap = (softcap > 0.0f);
+
+    // init dropout
+    bool has_dropout = p_dropout > 0.0f;
+    at::Tensor drop_mask_npu_tensor;
+    if (has_dropout) {
+        uint64_t num_elems = static_cast<uint64_t>(batch_size) * num_heads * seqlen_q * seqlen_k;
+        at::Generator gen = gen_.has_value() ? gen_.value() : at_npu::detail::getDefaultNPUGenerator();
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        auto [seed, offset] = gen.get<at_npu::NPUGeneratorImpl>()->philox_engine_inputs(num_elems);
+        int64_t drop_mask_bit_num = static_cast<int64_t>(batch_size) * num_heads * seqlen_q * ((seqlen_k + 7) / 8 * 8);
+        drop_mask_npu_tensor = at_npu::native::npu_dropout_gen_mask(
+            torch::empty({0}, at::device(at::kPrivateUse1).dtype(at::kFloat)), {drop_mask_bit_num}, p_dropout, seed,
+            offset, false, false);
+        uint64_t* rng_state_ptr = reinterpret_cast<uint64_t*>(const_cast<void*>(rng_state.data_ptr()));
+        rng_state_ptr[0] = seed;
+        rng_state_ptr[1] = offset;
+    }
 
     // init softmax lse — head-major BNS: {batch, num_heads, seqlen_q} (matches v3).
     at::Tensor softmaxlse = at::empty({batch_size, num_heads, seqlen_q},
@@ -607,6 +669,12 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
         maskDevice = hasMask ? metaBase : nullptr;
         workspace_tensor = at::empty({static_cast<int64_t>(fa_metadata::WorkSpaceSize(blockDim))},
                                      at::device(at::kPrivateUse1).dtype(at::kByte));
+        // The AICPU tiling does not carry the dropout fields; patch them in
+        // with stream-ordered copies (after the AICPU metadataDone event).
+        PatchTilingDropoutFields(schedMd, fa_metadata::TilingOffset(hasMask),
+                                 1.0f / (1.0f - p_dropout),
+                                 return_softmax ? static_cast<uint8_t *>(const_cast<void *>(p.data_ptr())) : nullptr,
+                                 has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr);
     } else {
     if (is_causal || is_local) {
         at::Tensor mask_cpu_tensor = at::empty({2048, 2048}, at::device(c10::kCPU).dtype(at::kByte));
@@ -655,12 +723,17 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
         tiling_cpu_ptr->set_scaleValue(softmax_scale);
     }
     tiling_cpu_ptr->set_softcapValue(softcap);
+    tiling_cpu_ptr->set_dropoutValue(1.0f / (1.0f - p_dropout));
     tiling_cpu_ptr->set_maxQSeqlen(seqlen_q);
+    tiling_cpu_ptr->set_maxKvSeqlen(seqlen_k);
     tiling_cpu_ptr->set_mm1OutSize(mm1OutSize);
     tiling_cpu_ptr->set_smOnlineOutSize(smOnlineOutSize);
     tiling_cpu_ptr->set_mm2OutSize(mm2OutSize);
     tiling_cpu_ptr->set_UpdateSize(UpdateSize);
     tiling_cpu_ptr->set_workSpaceSize(workSpaceSize);
+    tiling_cpu_ptr->set_pDevice(return_softmax ? static_cast<uint8_t*>(const_cast<void*>(p.data_ptr())) : nullptr);
+    tiling_cpu_ptr->set_dropMaskDevice(
+        has_dropout ? static_cast<uint8_t*>(const_cast<void*>(drop_mask_npu_tensor.data_ptr())) : nullptr);
 
     uint32_t totalTaskNum = 0;
     uint32_t groupSize = num_heads / num_heads_k;
@@ -698,7 +771,6 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     uint8_t * blockTableDevice = nullptr; // will not be used in non-kvcahce fwd api
 
     // run kernel
-    auto aclStream = c10_npu::getCurrentNPUStream().stream(false);
     // BSND, non-paged forward (IS_TND=false, paged_KV=false, no flash-decode).
     FwdLaunchArgs fwd_args;
     fwd_args.blockDim = blockDim;
@@ -710,6 +782,8 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
     fwd_args.has_softcap = has_softcap;
+    fwd_args.return_softmax = return_softmax;
+    fwd_args.has_dropout = has_dropout;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -772,22 +846,14 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     TORCH_CHECK(!seqused_k_.has_value(), "NPU FlashAttention does not support seqused_k.");
     TORCH_CHECK(!leftpad_k_.has_value(), "NPU FlashAttention does not support leftpad_k.");
     TORCH_CHECK(!alibi_slopes_.has_value(), "NPU FlashAttention does not support alibi_slopes.");
-    TORCH_CHECK(p_dropout == 0.0, "NPU FlashAttention does not support dropout.");
+    TORCH_CHECK(p_dropout >= 0.0f && p_dropout < 1.0f, "p_dropout must be in [0.0, 1.0)");
     TORCH_CHECK(!zero_tensors, "NPU FlashAttention does not support zero_tensors.");
     TORCH_CHECK(softcap >= 0.0f, "softcap must be non-negative (0.0 disables softcap)");
-    TORCH_CHECK(!return_softmax, "NPU FlashAttention does not support return_softmax.");
     TORCH_CHECK(k.dtype() == q.dtype(), "query and key must have the same dtype");
     TORCH_CHECK(v.dtype() == q.dtype(), "query and value must have the same dtype");
     TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-
-    at::Tensor out;
-    if (out_.has_value()) {
-        out = out_.value();
-    }  else {
-        out = torch::empty_like(q);
-    }
 
     // 可选输入，当前均不支持
     at::Tensor seqlens_k, leftpad_k, alibi_slopes, block_table;
@@ -859,6 +925,32 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         }
     }
 
+    at::Tensor out = (out_.has_value()) ? out_.value() : torch::empty_like(q);
+    auto opts = q.options().device(at::kPrivateUse1);
+    auto p = torch::empty({0}, opts);
+    if (return_softmax) {
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::zeros({batch_size, num_heads, max_seqlen_q, max_seqlen_k}, opts);
+    }
+    auto rng_state = torch::empty({2}, at::device(c10::kCPU).dtype(torch::kInt64));
+
+    bool has_dropout = p_dropout > 0.0f;
+    at::Tensor drop_mask_npu_tensor;
+    if (has_dropout) {
+        uint64_t num_elems = static_cast<uint64_t>(batch_size) * num_heads * max_seqlen_q * max_seqlen_k;
+        at::Generator gen = gen_.has_value() ? gen_.value() : at_npu::detail::getDefaultNPUGenerator();
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        auto [seed, offset] = gen.get<at_npu::NPUGeneratorImpl>()->philox_engine_inputs(num_elems);
+        int64_t drop_mask_bit_num =
+            static_cast<int64_t>(batch_size) * num_heads * max_seqlen_q * ((max_seqlen_k + 7) / 8 * 8);
+        drop_mask_npu_tensor = at_npu::native::npu_dropout_gen_mask(
+            torch::empty({0}, at::device(at::kPrivateUse1).dtype(at::kFloat)), {drop_mask_bit_num}, p_dropout, seed,
+            offset, false, false);
+        uint64_t* rng_state_ptr = reinterpret_cast<uint64_t*>(const_cast<void*>(rng_state.data_ptr()));
+        rng_state_ptr[0] = seed;
+        rng_state_ptr[1] = offset;
+    }
+
     bool has_softcap = (softcap > 0.0f);
     // LSE output is head-major NT: {num_heads, T} (matches v3).
     at::Tensor softmaxlse = at::empty({num_heads, T}, at::device(at::kPrivateUse1).dtype(at::kFloat)); // lse
@@ -882,6 +974,12 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         maskDevice = hasMask ? metaBase : nullptr;
         workspace_tensor = at::empty({static_cast<int64_t>(fa_metadata::WorkSpaceSize(blockDim))},
                                      at::device(at::kPrivateUse1).dtype(at::kByte));
+        // Same dropout patch as mha_fwd: stream-ordered copies fill the
+        // AICPU tiling's missing dropout fields.
+        PatchTilingDropoutFields(schedMd, fa_metadata::TilingOffset(hasMask),
+                                 1.0f / (1.0f - p_dropout),
+                                 return_softmax ? static_cast<uint8_t *>(const_cast<void *>(p.data_ptr())) : nullptr,
+                                 has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr);
     } else {
     at::Tensor tiling_cpu_tensor = at::empty({static_cast<int64_t>(sizeof(FAInferTilingData))},
                                              at::device(c10::kCPU).dtype(at::kByte));
@@ -908,7 +1006,12 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         tiling_cpu_ptr->set_scaleValue(softmax_scale);
     }
     tiling_cpu_ptr->set_softcapValue(softcap);
+    tiling_cpu_ptr->set_dropoutValue(1.0f / (1.0f - p_dropout));
     tiling_cpu_ptr->set_maxQSeqlen(max_seqlen_q);
+    tiling_cpu_ptr->set_maxKvSeqlen(max_seqlen_k);
+    tiling_cpu_ptr->set_pDevice(return_softmax ? static_cast<uint8_t*>(const_cast<void*>(p.data_ptr())) : nullptr);
+    tiling_cpu_ptr->set_dropMaskDevice(
+        has_dropout ? static_cast<uint8_t*>(const_cast<void*>(drop_mask_npu_tensor.data_ptr())) : nullptr);
 
     uint64_t WORKSPACE_BLOCK_SIZE_DB = 128 * 512;  // 工作空间块大小 ，每次计算128 * 512
     uint64_t PRELANCH_NUM = 3;
@@ -995,6 +1098,8 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     fwd_args.is_local = is_local;
     fwd_args.flashDecodeFlag = false;
     fwd_args.has_softcap = has_softcap;
+    fwd_args.return_softmax = return_softmax;
+    fwd_args.has_dropout = has_dropout;
     fwd_args.qDevice = qDevice;
     fwd_args.kDevice = kDevice;
     fwd_args.vDevice = vDevice;
@@ -1012,9 +1117,6 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     };
     at_npu::native::OpCommand::RunOpApiV2("ascendc_fa_infer", launch_fa_infer);
 
-    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(at::Device(at::kPrivateUse1));
-    at::Tensor rng_state =  torch::empty({2}, options.dtype(torch::kInt64));
-    at::Tensor p = torch::empty({ 0 }, options.dtype(torch::kInt64));
     return {out, softmaxlse, p, rng_state};
 }
 
@@ -1096,13 +1198,13 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     const bool local_is_causal = local_window_size_left < 0 && local_window_size_right == 0;
     const bool is_local = (local_window_size_left >= 0 || local_window_size_right >= 0) && !local_is_causal;
 
-    if (!seqlens_q.equal(seqlens_k) || is_local || headdim != 128) { // varlen optimized kernel only supports headdim equal to 128
+    // varlen optimized kernel only supports headdim equal to 128
+    if (!seqlens_q.equal(seqlens_k) || is_local || p_dropout > 0.0f || headdim != 128) {
         float scale = softmax_scale > 0.f ? softmax_scale : (1.0f / sqrt(static_cast<float>(headdim)));
         return launch_fag_general(
-            dout, q, k, v, out, softmax_lse, dq, dk, dv,
-            seqlens_q, seqlens_k,
-            max_seqlen_q, max_seqlen_k,
-            scale, softcap, local_is_causal, local_window_size_left, local_window_size_right, deterministic);
+            dout, q, k, v, out, softmax_lse, dq, dk, dv, seqlens_q, seqlens_k, max_seqlen_q, max_seqlen_k, scale,
+            softcap, local_is_causal, local_window_size_left, local_window_size_right, deterministic, p_dropout,
+            rng_state);
     }
 
     // tiling args set
@@ -1251,10 +1353,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     float scale = softmax_scale > 0.f ? softmax_scale
                                       : (1.0f / sqrt(static_cast<float>(qsizes[3])));
     return launch_fag_general(
-        dout, q, k, v, out, softmax_lse, dq, dk, dv,
-        std::nullopt, std::nullopt,
-        qsizes[1], ksizes[1],
-        scale, softcap, is_causal, window_size_left, window_size_right, deterministic);
+        dout, q, k, v, out, softmax_lse, dq, dk, dv, std::nullopt, std::nullopt, qsizes[1], ksizes[1], scale, softcap,
+        is_causal, window_size_left, window_size_right, deterministic, p_dropout, rng_state);
 }
 
 at::Tensor get_scheduler_metadata(

--- a/csrc/ascend910/flash_attn_npu/fwd_dispatch.hpp
+++ b/csrc/ascend910/flash_attn_npu/fwd_dispatch.hpp
@@ -35,6 +35,8 @@ struct FwdLaunchArgs {
     bool is_local;              // sliding-window attention (MASK_SWA)
     bool flashDecodeFlag;       // only meaningful for the BSND (kvcache) path
     bool has_softcap;
+    bool return_softmax = false;
+    bool has_dropout = false;
     uint8_t *qDevice;
     uint8_t *kDevice;
     uint8_t *vDevice;

--- a/csrc/ascend910/flash_attn_npu/fwd_dispatch_impl.hpp
+++ b/csrc/ascend910/flash_attn_npu/fwd_dispatch_impl.hpp
@@ -31,10 +31,10 @@
 #include "mha_fwd_kvcache.cpp"
 
 // 8-param FAInfer (no IS_FD template arg — flash-decode moved to tiling).
-#define FWD_LAUNCH(DTYPE, PAGED, MASK, LAYOUT_ENUM, SOFTCAP)                       \
+#define FWD_LAUNCH(DTYPE, PAGED, MASK, LAYOUT_ENUM, SOFTCAP, RETURN_SOFTMAX, DROPOUT)                       \
     SplitFuse::FAInfer<DTYPE, DTYPE, float, PAGED,                                 \
                        FaiKenel::MaskType::MASK, LAYOUT_ENUM,                      \
-                       Catlass::Epilogue::LseModeT::OUT_ONLY, SOFTCAP>             \
+                       Catlass::Epilogue::LseModeT::OUT_ONLY, SOFTCAP, RETURN_SOFTMAX, DROPOUT>             \
         <<<blockDim, nullptr, aclStream>>>(                                        \
             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice,     \
             oDevice, softmaxLseDevice, qSeqDevice, kvSeqDevice,                    \
@@ -52,6 +52,8 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
     const bool is_local = a.is_local;
     const bool flashDecodeFlag = a.flashDecodeFlag;
     const bool has_softcap = a.has_softcap;
+    const bool return_softmax = a.return_softmax;
+    const bool has_dropout = a.has_dropout;
     uint8_t *qDevice = a.qDevice;
     uint8_t *kDevice = a.kDevice;
     uint8_t *vDevice = a.vDevice;
@@ -68,41 +70,186 @@ void launch_fwd_impl(const FwdLaunchArgs &a) {
     if (paged_KV) {
         if (is_local) {
             if (has_softcap) {
-                FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_SWA, LAYOUT, false, false, false);
+                    }
+                }
             }
         } else if (is_causal) {
             if (has_softcap) {
-                FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, MASK_CAUSAL, LAYOUT, false, false, false);
+                    }
+                }
             }
         } else {
+            // NO_MASK
             if (has_softcap) {
-                FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, true, NO_MASK, LAYOUT, false, false, false);
+                    }
+                }
             }
         }
     } else {
         if (is_local) {
             if (has_softcap) {
-                FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_SWA, LAYOUT, false, false, false);
+                    }
+                }
             }
         } else if (is_causal) {
             if (has_softcap) {
-                FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, MASK_CAUSAL, LAYOUT, false, false, false);
+                    }
+                }
             }
         } else {
             if (has_softcap) {
-                FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, true);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, true, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, true, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, true, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, true, false, false);
+                    }
+                }
             } else {
-                FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, false);
+                if (return_softmax) {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, false, true, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, false, true, false);
+                    }
+                } else {
+                    if (has_dropout) {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, false, false, true);
+                    } else {
+                        FWD_LAUNCH(DType, false, NO_MASK, LAYOUT, false, false, false);
+                    }
+                }
             }
         }
     }

--- a/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
@@ -93,6 +93,8 @@ namespace SplitFuse {
             AscendC::GlobalTensor<ElementP>& gP;
             AscendC::GlobalTensor<ElementOTmp>& gOTmp;
             AscendC::GlobalTensor<ElementOTmp>& gOUpdate;
+            AscendC::GlobalTensor<ElementP>& gPret;
+            AscendC::GlobalTensor<ElementMask>& gDrop;
         };
 
         __aicore__ inline
@@ -120,7 +122,9 @@ namespace SplitFuse {
             windowSizeRight = fATilingData->windowSizeRight;
             scaleValue = fATilingData->scaleValue;
             softcapValue = fATilingData->softcapValue;
+            dropoutValue = fATilingData->dropoutValue;
             maxQSeqlen = fATilingData->maxQSeqlen;
+            maxKvSeqlen = fATilingData->maxKvSeqlen;
             flashDecodeFlag = fATilingData->flashDecodeFlag;
 
             // FD workspace sizing: reserve head of workspace for gLseFD/gOFD.
@@ -167,13 +171,25 @@ namespace SplitFuse {
             AscendC::GlobalTensor<ElementOTmp> gOUpdate;
             gOUpdate.SetGlobalBuffer((__gm__ ElementOTmp *)(params.workSpace + Lsesize + Losize +
                 mm1OutSize + smOnlineOutSize + mm2OutSize));
+            
+            AscendC::GlobalTensor<ElementP> gPret;
+            gPret.SetGlobalBuffer((__gm__ ElementP *)(fATilingData->pDevice));
+            AscendC::GlobalTensor<ElementMask> gDrop;
+            gDrop.SetGlobalBuffer((__gm__ ElementMask *)(fATilingData->dropMaskDevice));
 
             GlobalTensorBundle globalTensors{
                 gQ, gK, gV, gMask, gBlockTable,
                 gActualQseqlen, gActualKvseqlen,
                 gO, gLse, gLseFD, gOFD,
-                gS, gP, gOTmp, gOUpdate
+                gS, gP, gOTmp, gOUpdate, gPret, gDrop
             };
+
+            strideQ = static_cast<uint64_t>(qHeads * embed);
+            strideO = static_cast<uint64_t>(qHeads * embedV);
+            strideK = static_cast<uint64_t>(kvHeads * embed);
+            strideV = static_cast<uint64_t>(kvHeads * embedV);
+            stridePret = static_cast<uint64_t>(maxQSeqlen * maxKvSeqlen);
+            strideDrop = static_cast<uint64_t>(maxQSeqlen * CeilDiv(maxKvSeqlen, 8));
 
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
@@ -231,15 +247,13 @@ namespace SplitFuse {
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
 
-            epilogueOnlineSoftmax.init(resource, scaleValue, softcapValue);
-            epilogueRescaleO.init(resource);
+            epilogueOnlineSoftmax.init(
+                resource, scaleValue, softcapValue, gPret, stridePret, gDrop, strideDrop, maxKvSeqlen);
+            epilogueRescaleO.init(resource, dropoutValue);
 
             coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
 #endif
-            strideQ = static_cast<uint64_t>(qHeads * embed);
-            strideO = static_cast<uint64_t>(qHeads * embedV);
-            strideK = static_cast<uint64_t>(kvHeads * embed);
-            strideV = static_cast<uint64_t>(kvHeads * embedV);
+
             embedRound = RoundUp(embed, FaiKenel::BLOCK_SIZE);
             embedRoundV = RoundUp(embedV, FaiKenel::BLOCK_SIZE);
             groupSize = qHeads / kvHeads;
@@ -467,6 +481,8 @@ namespace SplitFuse {
             auto& gP = globalTensors.gP;
             auto& gOTmp = globalTensors.gOTmp;
             auto& gOUpdate = globalTensors.gOUpdate;
+            auto& gPret = globalTensors.gPret;
+            auto& gDrop = globalTensors.gDrop;
 
             uint32_t qSeqlen = maxQSeqlen;
             uint32_t kvSeqlen = static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx));
@@ -540,6 +556,11 @@ namespace SplitFuse {
             uint64_t gmOffsetLse = lseBOffset +
                 static_cast<uint64_t>(qNStartIdx) * lseHeadStride +
                 static_cast<uint64_t>(lseTokenOffset);
+
+            uint64_t gmOffsetPret = static_cast<uint64_t>(BIdx * qHeads + qNStartIdx) * stridePret +
+                                    static_cast<uint64_t>(qSBlockIdx * curQSBlockTile) * maxKvSeqlen;
+            uint64_t gmOffsetDrop = static_cast<uint64_t>(BIdx * qHeads + qNStartIdx) * strideDrop +
+                                    static_cast<uint64_t>(qSBlockIdx * curQSBlockTile) * CeilDiv(maxKvSeqlen, 8);
 
             uint32_t qSBlockSize = (qSBlockIdx == (curQSBlockNum - 1U)) ?
                 (qSeqlen - qSBlockIdx * curQSBlockTile) : curQSBlockTile;
@@ -696,6 +717,8 @@ namespace SplitFuse {
                     uint64_t gmOffsetP = gmOffsetS;
                     uint32_t kvSStartIdx = kvSIdx * MAX_KV_STACK_LEN;
                     uint32_t kvSEndIdx = kvSStartIdx + stackSeqTile;
+                    epilogueOnlineSoftmax.set_gmOffsetPret(gmOffsetPret + kvSStartIdx);
+                    epilogueOnlineSoftmax.set_gmOffsetDrop(gmOffsetDrop + kvSStartIdx / 8);
                     if constexpr (MASK_TYPE == FaiKenel::MaskType::MASK_CAUSAL) {
                         int64_t triUp =
                             static_cast<int64_t>(noSkipKvS) - static_cast<int64_t>(qSBlockSize);
@@ -1006,14 +1029,18 @@ namespace SplitFuse {
         int64_t  windowSizeRight;
         float    scaleValue;
         float    softcapValue;
+        float    dropoutValue;
         uint32_t totalQTokens;
         uint32_t maxQSeqlen;
+        uint32_t maxKvSeqlen;
         uint32_t flashDecodeFlag;
 
         uint64_t strideQ;
         uint64_t strideO;
         uint64_t strideK;
         uint64_t strideV;
+        uint64_t stridePret;
+        uint64_t strideDrop;
         uint32_t embedRound;
         uint32_t embedRoundV;
         uint32_t groupSize;
@@ -1039,7 +1066,9 @@ namespace SplitFuse {
         FaiKenel::MaskType maskCategory = FaiKenel::MaskType::NO_MASK,
         FaiKenel::inputLayout inLayout = FaiKenel::inputLayout::TND,
         Epilogue::LseModeT lseMode = Epilogue::LseModeT::NONE,
-        bool HAS_SOFTCAP = false>
+        bool HAS_SOFTCAP = false,
+        bool RETURN_SOFTMAX = false,
+        bool HAS_DROPOUT = false>
     __global__ __aicore__ void FAInfer(
         uint64_t fftsAddr,
         GM_ADDR q,
@@ -1087,7 +1116,8 @@ namespace SplitFuse {
         using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK,
                                                    QType, KType, SType>;
 
-        using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP>;
+        using DispatchPolicyOnlineSoftmax =
+            Epilogue::EpilogueAtlasA2OnlineSoftmaxT<lseMode, IntermCalcPrec, HAS_SOFTCAP, RETURN_SOFTMAX, HAS_DROPOUT>;
         using PType = Gemm::GemmType<ElementP, LayoutP>;
         using maskType = Gemm::GemmType<ElementMask, LayoutMask>;
         using EpilogueOnlineSoftmax =
@@ -1101,7 +1131,7 @@ namespace SplitFuse {
         using BlockMmadPV = Gemm::Block::BlockMmad<DispatchPolicyPV, L1TileShapePV, L0TileShapePV,
                                                    PType, VType, OTmpType>;
 
-        using DispatchPolicyRescaleO = Epilogue::EpilogueAtlasA2RescaleOT<lseMode, IntermCalcPrec>;
+        using DispatchPolicyRescaleO = Epilogue::EpilogueAtlasA2RescaleOT<lseMode, IntermCalcPrec, HAS_DROPOUT>;
         using OType = Gemm::GemmType<ElementO, LayoutO>;
         using OUpdateType = Gemm::GemmType<ElementUpdate, LayoutUpdate>;
         using LseType = Gemm::GemmType<ElementLse, LayoutLse>;

--- a/csrc/ascend910/flash_attn_npu/online_softmax.hpp
+++ b/csrc/ascend910/flash_attn_npu/online_softmax.hpp
@@ -23,15 +23,17 @@ template <
     class InputType_,
     class MaskType_,
     LseModeT LSE_MODE_,
-    bool HAS_SOFTCAP_>
+    bool HAS_SOFTCAP_,
+    bool RETURN_SOFTMAX_,
+    bool HAS_DROPOUT_>
 class BlockEpilogue<
-    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>,
+    EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_, RETURN_SOFTMAX_, HAS_DROPOUT_>,
     OutputType_,
     InputType_,
     MaskType_>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_>;
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmaxT<LSE_MODE_, float, HAS_SOFTCAP_, RETURN_SOFTMAX_, HAS_DROPOUT_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
     using ElementOutput = typename OutputType_::Element;
     using ElementInput = typename InputType_::Element;
@@ -67,7 +69,9 @@ public:
     ~BlockEpilogue() {}
 
     __aicore__ inline
-    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_)
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_, float softcapValue_, 
+        AscendC::GlobalTensor<ElementOutput> gPret_, uint64_t stridePret_, 
+        AscendC::GlobalTensor<ElementMask> gDrop_, uint64_t strideDrop_, uint32_t maxKvSeqlen_)
     {
         // Allocate UB space
         constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
@@ -84,9 +88,16 @@ public:
         constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t DROP_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
 
         scaleValue = scaleValue_;
         softcapValue = softcapValue_;
+        gPret = gPret_;
+        stridePret = stridePret_;
+        gDrop = gDrop_;
+        strideDrop = strideDrop_;
+        maxKvSeqlen = maxKvSeqlen_;
+
         lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
         lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
         maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
@@ -100,12 +111,19 @@ public:
         llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
         tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
         glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
+        dropUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(DROP_UB_TENSOR_OFFSET);
+    }
+    
+    __aicore__ inline
+    void set_gmOffsetPret(uint64_t gmOffsetPret_)
+    {
+        gmOffsetPret = gmOffsetPret_;
     }
 
-    template <typename T>
-    __aicore__ inline T Min(T a, T b)
+    __aicore__ inline
+    void set_gmOffsetDrop(uint64_t gmOffsetDrop_)
     {
-        return (a > b) ? b : a;
+        gmOffsetDrop = gmOffsetDrop_;
     }
 
     __aicore__ inline
@@ -813,6 +831,93 @@ public:
                 rowNumCurLoop, columnNumRound / BLOCK_SIZE, 0, (columnNumPad - columnNumRound) / BLOCK_SIZE));
     }
 
+    __aicore__ inline
+    void CopyDropMaskToUb(
+        uint32_t qNOffset, uint32_t qSIdxCurBlock, uint32_t qSOffset, uint32_t rowNum, uint32_t columnNum,
+        uint32_t qSBlockSize)
+    {
+        uint32_t rowsDone = 0;
+        while (rowsDone < rowNum) {
+            uint32_t rowsCurHead = Min(rowNum - rowsDone, qSBlockSize - qSIdxCurBlock);
+            AscendC::DataCopyPad(
+                dropUbTensor[rowsDone * ((columnNum > 256) ? 64 : 32)],
+                gDrop[gmOffsetDrop + qNOffset + qSOffset],
+                AscendC::DataCopyExtParams(
+                    rowsCurHead, CeilDiv(columnNum, 8) * sizeof(ElementMask),
+                    (CeilDiv(maxKvSeqlen, 8) - CeilDiv(columnNum, 8)) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>());
+            rowsDone += rowsCurHead;
+            qNOffset += strideDrop;
+            qSIdxCurBlock = 0;
+            qSOffset = 0;
+        }
+    }
+
+    __aicore__ inline
+    void ApplyDropoutNegate(uint32_t sUbOffset, uint32_t rowNum, uint32_t columnNum, uint32_t columnNumRound)
+    {
+        auto t0 = lmUbTensor.template ReinterpretCast<half>();
+        auto t1 = hmUbTensor.template ReinterpretCast<half>();
+        auto u0 = t0.template ReinterpretCast<uint16_t>();
+        auto u1 = t1.template ReinterpretCast<uint16_t>();
+        for (uint32_t r = 0; r < rowNum; r++) {
+            AscendC::Duplicate(t0, static_cast<half>(0.0f), columnNumRound);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Select(
+                t0, dropUbTensor[r * ((columnNum > 256) ? 64 : 32)], t0, static_cast<half>(-0.0f),
+                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, columnNumRound);
+            AscendC::PipeBarrier<PIPE_V>();
+            auto up = lpUbTensor[sUbOffset][r * columnNumRound].template ReinterpretCast<uint16_t>();
+            AscendC::Or(u1, up, u0, columnNumRound);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::And(up, up, u0, columnNumRound);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Not(up, up, columnNumRound);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::And(up, up, u1, columnNumRound);
+        }
+    }
+
+    __aicore__ inline
+    void ApplyDropoutStd(uint32_t sUbOffset, uint32_t rowNum, uint32_t columnNum, uint32_t columnNumRound)
+    {
+        if (columnNum == 512 || columnNum == 256) {
+            AscendC::Select(
+                lpUbTensor[sUbOffset].template ReinterpretCast<half>(), dropUbTensor,
+                lpUbTensor[sUbOffset].template ReinterpretCast<half>(), static_cast<half>(0.0f),
+                AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNum * columnNumRound);
+        } else {
+            for (uint32_t r = 0; r < rowNum; r++) {
+                AscendC::Select(
+                    lpUbTensor[sUbOffset][r * columnNumRound].template ReinterpretCast<half>(),
+                    dropUbTensor[r * ((columnNum > 256) ? 64 : 32)],
+                    lpUbTensor[sUbOffset][r * columnNumRound].template ReinterpretCast<half>(),
+                    static_cast<half>(0.0f), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, columnNumRound);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void CopyPretUbToGm(
+        uint32_t sUbOffset, uint64_t qNOffset, uint32_t qSIdxCurBlock, uint32_t qSOffset, uint32_t rowNum,
+        uint32_t columnNum, uint32_t columnNumRound, uint32_t qSBlockSize)
+    {
+        uint32_t rowsDone = 0;
+        while (rowsDone < rowNum) {
+            uint32_t rowsCurHead = Min(rowNum - rowsDone, qSBlockSize - qSIdxCurBlock);
+            AscendC::DataCopyPad(
+                gPret[gmOffsetPret + qNOffset + qSOffset], lpUbTensor[sUbOffset][rowsDone * columnNumRound],
+                AscendC::DataCopyExtParams(
+                    rowsCurHead, columnNum * sizeof(ElementOutput),
+                    (columnNumRound - columnNum) * sizeof(ElementOutput) / 32,
+                    (maxKvSeqlen - columnNum) * sizeof(ElementOutput), 0));
+            rowsDone += rowsCurHead;
+            qNOffset += stridePret;
+            qSIdxCurBlock = 0;
+            qSOffset = 0;
+        }
+    }
+
     template <bool doTriUMask>
     __aicore__ inline
     void SubCoreCompute(
@@ -820,7 +925,8 @@ public:
         uint32_t rowOffset, uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
         uint32_t isFirstRowLoop, uint32_t isLastRowLoop,
         uint32_t columnNumRound, uint32_t pingpongFlag,
-        uint32_t curStackTileMod, bool isSplitKV, bool startsWithMaskThenNomaskFlag = false)
+        uint32_t curStackTileMod, uint32_t rowOffsetIoGm, uint32_t qSBlockSize,
+        bool isSplitKV, bool startsWithMaskThenNomaskFlag = false)
     {
         uint32_t rowNumCurLoop = layoutOutput.shape(0);
         uint32_t rowNumCurLoopRound = RoundUp(rowNumCurLoop, FLOAT_BLOCK_SIZE);
@@ -838,6 +944,16 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
             }
         }
+
+        if constexpr (HAS_DROPOUT_) {
+            uint32_t qNOffset = (rowOffsetIoGm / qSBlockSize) * strideDrop;
+            uint32_t qSIdxCurBlock = rowOffsetIoGm % qSBlockSize;
+            uint32_t qSOffset = qSIdxCurBlock * CeilDiv(maxKvSeqlen, 8);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+            CopyDropMaskToUb(qNOffset, qSIdxCurBlock, qSOffset, rowNumCurLoop, columnNum, qSBlockSize);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+        }
+
         CalcLocalRowMax(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
         UpdateGlobalRowMax(
             rowNumCurLoop, rowNumCurLoopRound,
@@ -852,6 +968,25 @@ public:
         }
 
         DownCastP(sUbOffset, rowNumCurLoop, columnNumRound);
+        if constexpr (HAS_DROPOUT_) {
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            if constexpr (RETURN_SOFTMAX_) {
+                ApplyDropoutNegate(sUbOffset, rowNumCurLoop, columnNum, columnNumRound);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID3);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID3);
+                uint64_t qNOffset = static_cast<uint64_t>(rowOffsetIoGm / qSBlockSize) * stridePret;
+                uint32_t qSIdxCurBlock = rowOffsetIoGm % qSBlockSize;
+                uint32_t qSOffset = qSIdxCurBlock * maxKvSeqlen;
+                CopyPretUbToGm(
+                    sUbOffset, qNOffset, qSIdxCurBlock, qSOffset, rowNumCurLoop, columnNum, columnNumRound,
+                    qSBlockSize);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID3);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID3);
+            }
+            ApplyDropoutStd(sUbOffset, rowNumCurLoop, columnNum, columnNumRound);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+        }
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
 
         CalcLocalRowSum(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
@@ -859,6 +994,7 @@ public:
 
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
         CopyPUbToGm(gOutput, sUbOffset, rowNumCurLoop, columnNumRound, columnNumPad);
+
         if constexpr (!doTriUMask) {
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
             if (isLastNoMaskStackTile && isLastRowLoop) {
@@ -948,6 +1084,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     isSplitKV,
                     startsWithMaskThenNomaskFlag);
             }
@@ -1090,6 +1228,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     isSplitKV);
                 // next loop mask load (after P copy releases shared UB via EVENT_ID0)
                 if (rowLoopIdx < rowLoopNum) {
@@ -1308,6 +1448,8 @@ public:
                     columnNumRound,
                     pingpongFlag,
                     curStackTileMod,
+                    rowOffsetIoGm,
+                    qSBlockSize,
                     isSplitKV,
                     false);
                 // next loop mask load (after P copy releases shared UB via EVENT_ID0)
@@ -1344,6 +1486,14 @@ public:
 private:
     float scaleValue;
     float softcapValue;
+    uint64_t gmOffsetPret;
+    uint64_t stridePret;
+    uint64_t gmOffsetDrop;
+    uint64_t strideDrop;
+    uint32_t maxKvSeqlen;
+    AscendC::GlobalTensor<ElementOutput> gPret;
+    AscendC::GlobalTensor<ElementMask> gDrop;
+
     AscendC::LocalTensor<float> lsUbTensor;
     AscendC::LocalTensor<ElementOutput> lpUbTensor;
     AscendC::LocalTensor<ElementMask> maskUbTensor;
@@ -1357,6 +1507,7 @@ private:
     AscendC::LocalTensor<float> tvUbTensor;
     AscendC::LocalTensor<float> glUbTensor;
     AscendC::LocalTensor<float> softcapUbTensor;
+    AscendC::LocalTensor<ElementMask> dropUbTensor;
 };
 
 }

--- a/csrc/ascend910/flash_attn_npu/rescale_o.hpp
+++ b/csrc/ascend910/flash_attn_npu/rescale_o.hpp
@@ -22,16 +22,17 @@ template <
     class InputType_,
     class UpdateType_,
     class LseType_,
-    LseModeT LSE_MODE_>
+    LseModeT LSE_MODE_,
+    bool HAS_DROPOUT_>
 class BlockEpilogue<
-    EpilogueAtlasA2RescaleOT<LSE_MODE_, float>,
+    EpilogueAtlasA2RescaleOT<LSE_MODE_, float, HAS_DROPOUT_>,
     OutputType_,
     InputType_,
     UpdateType_,
     LseType_>
 {
 public:
-    using DispatchPolicy = EpilogueAtlasA2RescaleOT<LSE_MODE_, float>;
+    using DispatchPolicy = EpilogueAtlasA2RescaleOT<LSE_MODE_, float, HAS_DROPOUT_>;
     using ArchTag = typename DispatchPolicy::ArchTag;
 
     using ElementOutput = typename OutputType_::Element;
@@ -81,7 +82,7 @@ public:
     ~BlockEpilogue() {}
 
     __aicore__ inline
-    void init(Arch::Resource<ArchTag> &resource)
+    void init(Arch::Resource<ArchTag> &resource, float dropoutValue_)
     {
         // Allocate UB space
         constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
@@ -93,6 +94,8 @@ public:
         constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t LSE_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
         constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+
+        dropoutValue = dropoutValue_;
 
         loUbTensor = resource.ubBuf.template GetBufferByByte<float>(LO_UB_TENSOR_OFFSET);
         dmUbTensor = resource.ubBuf.template GetBufferByByte<float>(DM_UB_TENSOR_OFFSET);
@@ -392,6 +395,14 @@ public:
                 AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
             }
             AscendC::PipeBarrier<PIPE_V>();
+
+            if constexpr (HAS_DROPOUT_) {
+                // go = go * (1 / (1 - p))
+                AscendC::Muls<float, false>(
+                    goUbTensor32, goUbTensor32, dropoutValue, (uint64_t)0,
+                    CeilDiv(curRowNum * embedRound, FLOAT_VECTOR_SIZE), AscendC::UnaryRepeatParams());
+                AscendC::PipeBarrier<PIPE_V>();
+            }
 
             // *** go = castfp32to16(go)
             // FD: skip the fp32->fp16 cast when writing to splitParams.gCombineo
@@ -799,6 +810,7 @@ public:
     }
 
 private:
+    float dropoutValue;
     AscendC::LocalTensor<float> loUbTensor;
     AscendC::LocalTensor<float> dmUbTensor;
     AscendC::LocalTensor<float> hmUbTensor;

--- a/csrc/ascend910/flash_attn_npu/tilingdata.h
+++ b/csrc/ascend910/flash_attn_npu/tilingdata.h
@@ -52,6 +52,7 @@ struct FAInferTilingData {
     uint64_t workSpaceSize;
     float scaleValue;
     float softcapValue;
+    float dropoutValue;
     uint64_t padding1;
     uint64_t padding2;
     uint32_t padding3;
@@ -64,6 +65,8 @@ struct FAInferTilingData {
     uint32_t flashDecodeFlag;
     coreNode coreInfo[25];
     splitNode splitInfo[25];
+    __gm__ uint8_t* pDevice = nullptr;
+    __gm__ uint8_t* dropMaskDevice = nullptr;
 
     uint32_t get_numHeads() const { return numHeads; }
     uint32_t get_embeddingSize() const { return embeddingSize; }
@@ -87,6 +90,7 @@ struct FAInferTilingData {
     uint64_t get_workSpaceSize() const { return workSpaceSize; }
     float get_scaleValue() const { return scaleValue; }
     float get_softcapValue() const { return softcapValue; }
+    float get_dropoutValue() const { return dropoutValue; }
     uint64_t get_padding1() const { return padding1; }
     uint64_t get_padding2() const { return padding2; }
     uint32_t get_padding3() const { return padding3; }
@@ -94,6 +98,8 @@ struct FAInferTilingData {
     uint64_t get_splitOTotalSize() const { return splitOTotalSize; }
     uint32_t get_totalSplitNodeNum() const { return totalSplitNodeNum; }
     uint32_t get_needCoreNum() const { return needCoreNum; }
+    __gm__ uint8_t* get_pDevice() const { return pDevice; }
+    __gm__ uint8_t* get_dropMaskDevice() const { return dropMaskDevice; }
     uint32_t get_flashDecodeFlag() const { return flashDecodeFlag; }
 
     void set_numHeads(uint32_t value) { numHeads = value; }
@@ -118,6 +124,7 @@ struct FAInferTilingData {
     void set_workSpaceSize(uint64_t value) { workSpaceSize = value; }
     void set_scaleValue(float value) { scaleValue = value; }
     void set_softcapValue(float value) { softcapValue = value; }
+    void set_dropoutValue(float value) { dropoutValue = value; }
     void set_padding1(uint64_t value) { padding1 = value; }
     void set_padding2(uint64_t value) { padding2 = value; }
     void set_padding3(uint32_t value) { padding3 = value; }
@@ -125,6 +132,8 @@ struct FAInferTilingData {
     void set_splitOTotalSize(uint64_t value) { splitOTotalSize = value; }
     void set_totalSplitNodeNum(uint32_t value) { totalSplitNodeNum = value; }
     void set_needCoreNum(uint32_t value) { needCoreNum = value; }
+    void set_pDevice(__gm__ uint8_t* value) { pDevice = value; }
+    void set_dropMaskDevice(__gm__ uint8_t* value) { dropMaskDevice = value; }
     void set_flashDecodeFlag(uint32_t value) { flashDecodeFlag = value; }
 };
 

--- a/csrc/ascend910/flash_attn_npu_3/fag_tiling.cpp
+++ b/csrc/ascend910/flash_attn_npu_3/fag_tiling.cpp
@@ -402,19 +402,11 @@ int64_t GetFAGTilingParam(const FAGInfo &fagInfo, uint32_t aicNum, uint32_t aivN
     fagTilingData.s2CvTail = s2CvTailTmp == 0 ? fagTilingData.s2CvInner : s2CvTailTmp;
     fagTilingData.sfmgNormalAxisSize = fagTilingData.batch * fagTilingData.kvHeadNum * fagTilingData.g * fagTilingData.qSeqlen;
 
+    // Dropout is always handled in bit mode: the mask is the bit-packed output
+    // of aclnnDropoutGenMask (ceil(seqlen/8) bytes per row, bit 1 = keep), the
+    // same layout the forward kernel consumes. The legacy bool-mode workspace
+    // path (dropMaskSize / dropBeginAddr) is therefore never allocated.
     fagTilingData.dropoutIsDivisibleBy8 = 1;
-    if (fagTilingData.keepProb < 1) {
-        if (isTnd) {
-            for (int64_t i = 0; i < fagTilingData.batch; i++) {
-                if (fagTilingData.actualSeqKvlen[i] % BIT_NUMS != 0) {
-                    fagTilingData.dropoutIsDivisibleBy8 = 0;
-                    break;
-                }
-            }
-        } else if (fagTilingData.kvSeqlen % BIT_NUMS != 0) {
-            fagTilingData.dropoutIsDivisibleBy8 = 0;
-        }
-    }
 
     // 目前仅支持fp16/bf16
     fagTilingData.dataTypeSize = FP16_BYTES;

--- a/tests/fa_small_op_golden.py
+++ b/tests/fa_small_op_golden.py
@@ -221,6 +221,7 @@ def golden_bsnd_bwd_from_fwd(
     window_size_right,
     *,
     gtype=torch.float64,
+    drop_mask=None,
 ):
     """BSND 反传标杆。softmax_lse layout: FA (B, N, S_q)。"""
     del out
@@ -252,7 +253,8 @@ def golden_bsnd_bwd_from_fwd(
         compute_dtype,
         gtype=gtype,
     )
-    drop_mask = torch.tensor(1)
+    if drop_mask is None:
+        drop_mask = torch.tensor(1)
     dq_bn, dk_bn, dv_bn = tbackward_bsnd(
         dx_bn, q_bn, k_new, v_new, softmax_res, drop_mask, scale, softcap, dropout_p
     )
@@ -284,6 +286,7 @@ def golden_tnd_bwd_from_fwd(
     window_size_right,
     *,
     gtype=torch.float64,
+    drop_mask=None,
 ):
     """TND 反传标杆。softmax_lse layout: FA varlen (N, total_q) NT。"""
     del out
@@ -303,7 +306,8 @@ def golden_tnd_bwd_from_fwd(
     dq_golden = torch.empty_like(q, dtype=compute_dtype)
     dk_golden = torch.empty_like(k, dtype=compute_dtype)
     dv_golden = torch.empty_like(v, dtype=compute_dtype)
-    drop_mask = torch.tensor(1)
+    if drop_mask is None:
+        drop_mask = torch.tensor(1)
 
     for i, sq in enumerate(seqlens_q):
         sk = seqlens_k[i]
@@ -334,8 +338,11 @@ def golden_tnd_bwd_from_fwd(
             compute_dtype,
             gtype=gtype,
         )
+        drop_mask_i = (
+            drop_mask if drop_mask.dim() == 0 else drop_mask[i][:, :sq, :sk]
+        )
         dqi, dki, dvi = tbackward_tnd(
-            dxi, qi, ki_new, vi_new, softmax_res_i, drop_mask, scale, softcap, dropout_p
+            dxi, qi, ki_new, vi_new, softmax_res_i, drop_mask_i, scale, softcap, dropout_p
         )
         dki = sum_gqa_grad(dki, nheads, nheads_k, 1, sk, headdim)
         dvi = sum_gqa_grad(dvi, nheads, nheads_k, 1, sk, headdim)

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -99,6 +99,8 @@ def ref_flash_attention(
     mask,
     data_type,
     softcap=0.0,
+    drop_mask=None,
+    dropout_p=0.0,
     ):
     inner_prec = 0
     interm_dtype = torch.float16 if inner_prec == 1 else torch.float32
@@ -135,6 +137,9 @@ def ref_flash_attention(
             gm = None
         p_result, row_sum, dm, gm = softmax1(qk_result, kv_start == 0, gm, interm_dtype)
         p_result = p_result.to(data_type)
+        if drop_mask is not None and dropout_p > 0.0:
+            sub_drop_mask = drop_mask[:, :, kv_start : kv_start + sub_len]
+            p_result = p_result * sub_drop_mask / (1.0 - dropout_p)
         if kv_start == 0:
             gm_high = None
         lo = pvMM2(p_result, sub_value).to(interm_dtype)
@@ -444,31 +449,38 @@ def test_fa_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
 
 
 test_cases = [
-    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap)
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap, dropout_p)
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 0.0, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 0.0, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, True, False, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 0.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 0.0, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 0.0, 0.0),
     # Softcap
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 30.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 30.0),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 30.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, False, 30.0, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, False, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 30.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, False, 30.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, False, True, 30.0, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, False, 30.0, 0.0),
+    # Dropout (requires return_attn_probs=True)
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, False, 0.0, 0.5),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, True, 0.0, 0.1),
+    (torch.float16, 7, 1, 1, 512, 512, 128, True, False, 0.0, 0.3),
+    (torch.float16, 2, 2, 1, 777, 888, 128, True, False, 0.0, 0.2),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, True, 30.0, 0.1),
+    (torch.float16, 2, 4, 4, 128, 128, 128, True, True, 0.0, 0.5),
 ]
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap", test_cases)
-def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap, dropout_p", test_cases)
+def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, return_attn_probs, is_causal, softcap, dropout_p):
     q_min_range = -5.0
     q_max_range = 5.0
     kv_min_range = -5.0
@@ -491,7 +503,7 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
         query,
         key_cache,
         value_cache,
-        0.0,
+        dropout_p,
         causal=is_causal,
         window_size=[window_size_left,window_size_right],
         softcap=softcap,
@@ -499,8 +511,13 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
         return_attn_probs=return_attn_probs)
     if not return_attn_probs:
         out_out = ret
+        softmax_lse = None
+        drop_mask = None
     else:
         out_out, softmax_lse, S_dmask = ret
+        # Recover the dropout mask from the sign of the returned softmax
+        # (positive = kept, negative = dropped).
+        drop_mask = (S_dmask > 0).to(torch.float32).cpu() if dropout_p > 0.0 else None
 
     golden_out = torch.empty((batch_size, q_seqlen, num_heads, head_size), dtype=data_type)
     golden_lseL = torch.empty((batch_size, num_heads, q_seqlen), dtype=torch.float32)
@@ -516,9 +533,11 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
 
         query_cpu = query.detach().cpu()[i]
         if is_causal:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, atten_mask, data_type, softcap,
+                                                      drop_mask=drop_mask[i] if drop_mask is not None else None, dropout_p=dropout_p)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap)
+            output, golden_lse = ref_flash_attention(query_cpu, key_cache_per_batch, value_cache_per_batch, scale, None, data_type, softcap,
+                                                      drop_mask=drop_mask[i] if drop_mask is not None else None, dropout_p=dropout_p)
         out = output.reshape(q_seqlen, num_heads, head_size)
         golden_out[i:i+1] = out
         golden_lseL[i:i+1] = golden_lse.reshape(num_heads, q_seqlen)
@@ -531,57 +550,62 @@ def test_fa_fwd_custom_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen,
 
 test_cases = [
     # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap, cache_mode, block_size)
-    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1, 0.0, 0, 128),
-    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1, 0.0, 0, 128),
-    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1, 0.0, 0, 128),
-    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 0.0, 0, 128),
-    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 0.0, 0, 128),
-    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 0.0, 0, 128),
+    (torch.bfloat16, 1, 1, 1, 512, 1024, 128, True, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 0.0, 0, 128, 0.0),
     # SWA
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128, 0.0, 0, 128),
-    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256, 0.0, 0, 128),
-    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0, 0.0, 0, 128),
-    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0, 0.0, 0, 128),
-    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0, 0, 128),
-    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 0.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 0.0, 0, 128),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0, 0, 128),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 256, 128, 0.0, 0, 128, 0.0),
+    (torch.float16, 2, 4, 4, 256, 256, 128, False, 64, 128, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, False, 0, 256, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 2, 6, 2, 128, 256, 128, True, 127, 0, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 2, 4, 4, 128, 512, 128, True, 511, 0, 0.0, 0, 128, 0.0),
+    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0, 0, 128, 0.0),
+    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0, 0, 128, 0.0),
     # SWA + large GQA decode (EVENT_ID0 / rowLoopNum>1 hang regression)
-    (torch.float16, 1, 64, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128),
-    (torch.float16, 1, 128, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128),
-    (torch.float16, 1, 512, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128),
-    (torch.bfloat16, 1, 128, 1, 1, 1024, 128, True, 64, 0, 0.0, 0, 128),
+    (torch.float16, 1, 64, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128, 0.0),
+    (torch.float16, 1, 128, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128, 0.0),
+    (torch.float16, 1, 512, 1, 1, 1024, 128, True, 542, 647, 0.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 128, 1, 1, 1024, 128, True, 64, 0, 0.0, 0, 128, 0.0),
     # Softcap
-    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1,  30.0, 0, 128),
-    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 30.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 30.0, 0, 128),
-    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 30.0, 0, 128),
-    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 30.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0, 0, 128),
-    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 30.0, 0, 128),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 30.0, 0, 128),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0, 0, 128),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1,  30.0, 0, 128, 0.0),
+    (torch.float16, 7, 5, 1, 1777, 1888, 256, True, -1, -1, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64, True, -1, -1, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 7, 5, 1, 711, 8192, 111, True, -1, -1, 30.0, 0, 128, 0.0),
+    (torch.float16, 1, 2, 2, 64, 192, 128, False, 32, 64, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0, 0, 128, 0.0),
+    (torch.float16, 2, 1, 1, 512, 512, 128, False, 508, -256, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -128, 864, 30.0, 0, 128, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0, 0, 128, 0.0),
     # paged KV（cache_mode=1）
-    (torch.bfloat16, 1, 1, 1, 16, 1024, 128, False, -1, -1, 0.0, 1, 128),
-    (torch.float16, 2, 4, 2, 1, 2048, 128, True, -1, -1, 0.0, 1, 128),
-    (torch.bfloat16, 2, 8, 2, 8, 512, 128, True, -1, -1, 0.0, 1, 128),
-    (torch.bfloat16, 1, 32, 4, 4, 1024, 128, False, -1, -1, 0.0, 1, 128),
-    (torch.bfloat16, 3, 4, 1, 2, 1024, 128, True, -1, -1, 0.0, 1, 128),
-    (torch.float16, 1, 2, 1, 64, 1024, 128, True, 256, 0, 0.0, 1, 128),
-    (torch.bfloat16, 1, 4, 2, 32, 512, 128, False, 64, 128, 0.0, 1, 128),
-    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, True, -1, -1, 0.0, 1, 128),
-    (torch.bfloat16, 1, 8, 2, 8, 1024, 256, False, -1, -1, 0.0, 1, 128),
-    (torch.bfloat16, 2, 4, 2, 4, 512, 128, True, -1, -1, 30.0, 1, 128),
+    (torch.bfloat16, 1, 1, 1, 16, 1024, 128, False, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.float16, 2, 4, 2, 1, 2048, 128, True, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 2, 8, 2, 8, 512, 128, True, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 1, 32, 4, 4, 1024, 128, False, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 3, 4, 1, 2, 1024, 128, True, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.float16, 1, 2, 1, 64, 1024, 128, True, 256, 0, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 1, 4, 2, 32, 512, 128, False, 64, 128, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 4096, 128, True, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 1, 8, 2, 8, 1024, 256, False, -1, -1, 0.0, 1, 128, 0.0),
+    (torch.bfloat16, 2, 4, 2, 4, 512, 128, True, -1, -1, 30.0, 1, 128, 0.0),
+    # Dropout (uniform seqlens: S_dmask is (B, N, max_q, max_k) padded)
+    (torch.bfloat16, 3, 1, 1, 512, 512, 128, False, -1, -1, 0.0, 0, 128, 0.3),
+    (torch.float16, 5, 5, 1, 777, 888, 128, True, -1, -1, 0.0, 0, 128, 0.2),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -1, -1, 30.0, 0, 128, 0.1),
+    (torch.float16, 2, 4, 2, 512, 512, 128, False, -1, -1, 0.0, 1, 128, 0.3),
 ]
 
-@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap, cache_mode, block_size", test_cases)
-def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap, cache_mode, block_size):
+@pytest.mark.parametrize("data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap, cache_mode, block_size, dropout_p", test_cases)
+def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap, cache_mode, block_size, dropout_p):
     q_min_range = -5.0
     q_max_range = 5.0
     kv_min_range = -5.0
@@ -608,7 +632,6 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
 
     max_seqlen_q = q_seqlen
     max_seqlen_k = kv_seqlen
-    dropout_p = 0.0
     scale = 1.0 / (head_size ** 0.5)
     alibi_slopes = None
     deterministic = False
@@ -631,7 +654,7 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         if window_size_right_golden < 0:
             window_size_right_golden = kv_seqlen
 
-    output_npu, softmax_lse, _ = flash_attn_varlen_func(
+    output_npu, softmax_lse, S_dmask = flash_attn_varlen_func(
         query,
         key,
         value,
@@ -649,6 +672,9 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         return_attn_probs=return_attn_probs,
         block_table=block_table,
     )
+    # Recover the padded (B, N, max_q, max_k) dropout mask from the sign of
+    # the returned softmax (positive = kept, negative = dropped).
+    drop_mask = (S_dmask > 0).to(torch.float32).cpu() if dropout_p > 0.0 else None
     golden_out = torch.empty((batch_size * q_seqlen, num_heads, head_size), dtype=data_type)
     golden_lseL = torch.empty((num_heads, batch_size * q_seqlen), dtype=torch.float32)
     atten_mask = None
@@ -689,10 +715,13 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
             key_per_batch = key_cpu[(i - 1) * kv_seqlen : i * kv_seqlen]
             value_per_batch = value_cpu[(i - 1) * kv_seqlen : i * kv_seqlen]
         query_cpu = query.detach().cpu()[(i - 1) * q_seqlen : i * q_seqlen]
+        batch_drop_mask = drop_mask[i - 1] if drop_mask is not None else None
         if is_causal_golden or is_local_golden:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type, softcap)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, atten_mask, data_type, softcap,
+                                                      drop_mask=batch_drop_mask, dropout_p=dropout_p)
         else:
-            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type, softcap)
+            output, golden_lse = ref_flash_attention(query_cpu, key_per_batch, value_per_batch, scale, None, data_type, softcap,
+                                                      drop_mask=batch_drop_mask, dropout_p=dropout_p)
         out = output.reshape(q_seqlen , num_heads, head_size)
         if is_local_golden and atten_mask is not None:
             fully_masked = atten_mask.all(dim=-1)
@@ -703,6 +732,7 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     rtol = 1e-2
     atol = 1e-2
     torch.testing.assert_close(output_npu.cpu(), golden_out.cpu(), rtol=rtol, atol=atol)
+    torch.testing.assert_close(softmax_lse.cpu(), golden_lseL.cpu(), rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("data_type", [torch.float16])

--- a/tests/test_flash_attn_npu_v2_bwd.py
+++ b/tests/test_flash_attn_npu_v2_bwd.py
@@ -98,14 +98,15 @@ def rand_inputs(shape, data_type, device):
 def run_bsnd_bwd(
     query, key, value, dout, data_type,
     num_heads, kv_heads, scale, softcap, is_causal, window_size=(-1, -1),
+    dropout_p=DROPOUT_P,
 ):
     q_ag = query.detach().clone().requires_grad_(True)
     k_ag = key.detach().clone().requires_grad_(True)
     v_ag = value.detach().clone().requires_grad_(True)
     torch.npu.synchronize()
-    out_fa, lse_fa, _ = flash_attn_func(
+    out_fa, lse_fa, s_dmask = flash_attn_func(
         q_ag, k_ag, v_ag,
-        dropout_p=DROPOUT_P,
+        dropout_p=dropout_p,
         softmax_scale=scale,
         softcap=softcap,
         causal=is_causal,
@@ -115,11 +116,15 @@ def run_bsnd_bwd(
     dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_fa, (q_ag, k_ag, v_ag), dout)
     torch.npu.synchronize()
 
+    # Recover the dropout mask from the sign of the returned softmax
+    # (positive = kept, negative = dropped).
+    drop_mask = (s_dmask > 0).to(torch.float32).cpu() if dropout_p > 0.0 else None
     dq_golden, dk_golden, dv_golden = golden_bsnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, scale, softcap, DROPOUT_P,
+        num_heads, kv_heads, scale, softcap, dropout_p,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
+        drop_mask=drop_mask,
     )
     return data_type, dq_ag, dk_ag, dv_ag, dq_golden, dk_golden, dv_golden
 
@@ -130,6 +135,7 @@ def run_varlen_bwd(
     max_seqlen_q, max_seqlen_k,
     seqlens_q, seqlens_k,
     scale, softcap, is_causal, window_size=(-1, -1),
+    dropout_p=DROPOUT_P,
 ):
     num_heads = query.shape[1]
     kv_heads = key.shape[1]
@@ -138,11 +144,11 @@ def run_varlen_bwd(
     k_ag = key.detach().clone().requires_grad_(True)
     v_ag = value.detach().clone().requires_grad_(True)
     torch.npu.synchronize()
-    out_fa, lse_fa, _ = flash_attn_varlen_func(
+    out_fa, lse_fa, s_dmask = flash_attn_varlen_func(
         q_ag, k_ag, v_ag,
         cu_seqlens_q, cu_seqlens_k,
         max_seqlen_q, max_seqlen_k,
-        dropout_p=DROPOUT_P,
+        dropout_p=dropout_p,
         softmax_scale=scale,
         softcap=softcap,
         causal=is_causal,
@@ -152,11 +158,15 @@ def run_varlen_bwd(
     dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_fa, (q_ag, k_ag, v_ag), dout)
     torch.npu.synchronize()
 
+    # Recover the padded (B, N, max_q, max_k) dropout mask from the sign of
+    # the returned softmax (positive = kept, negative = dropped).
+    drop_mask = (s_dmask > 0).to(torch.float32).cpu() if dropout_p > 0.0 else None
     dq_golden, dk_golden, dv_golden = golden_tnd_bwd_from_fwd(
         query, key, value, dout, out_fa.detach(), lse_fa.detach(),
-        num_heads, kv_heads, seqlens_q, seqlens_k, scale, softcap, DROPOUT_P,
+        num_heads, kv_heads, seqlens_q, seqlens_k, scale, softcap, dropout_p,
         is_causal, window_size[0], window_size[1],
         gtype=GTYPE,
+        drop_mask=drop_mask,
     )
     return data_type, dq_ag, dk_ag, dv_ag, dq_golden, dk_golden, dv_golden
 
@@ -168,31 +178,37 @@ def assert_bwd_results(data_type, dq_ag, dk_ag, dv_ag, dq_golden, dk_golden, dv_
 
 
 test_cases_bsnd = [
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, 0.0),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 0.0),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 0.0),
-    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 0.0),
-    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
-    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
-    (torch.float16, 7, 1, 1, 512, 512, 128, False, 30.0),
-    (torch.float16, 4, 2, 1, 513, 513, 128, False, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 30.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 30.0),
-    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 30.0),
-    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 30.0),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p)
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 0.0, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 0.0, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 0.0, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 0.0, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 0.0, 0.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 0.0, 0.0),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 30.0, 0.0),
+    (torch.float16, 5, 4, 4, 1024, 1024, 128, True, 30.0, 0.0),
+    (torch.float16, 7, 1, 1, 512, 512, 128, False, 30.0, 0.0),
+    (torch.float16, 4, 2, 1, 513, 513, 128, False, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 30.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 30.0, 0.0),
+    (torch.bfloat16, 7, 1, 1, 512, 512, 128, False, 30.0, 0.0),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 30.0, 0.0),
+    # Dropout
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, False, 0.0, 0.3),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, 0.0, 0.5),
+    (torch.bfloat16, 4, 2, 1, 513, 513, 128, False, 0.0, 0.1),
+    (torch.float16, 1, 1, 1, 1024, 1024, 128, True, 30.0, 0.3),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p",
     test_cases_bsnd,
 )
 def test_fa_bsnd_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap,
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p,
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -203,38 +219,43 @@ def test_fa_bsnd_bwd(
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
         num_heads, kv_heads, scale, softcap, is_causal, (-1, -1),
+        dropout_p=dropout_p,
     )
     assert_bwd_results(*results)
 
 
 test_cases_bsnd_swa = [
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 0.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 0.0),
-    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 0.0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 30.0),
-    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 30.0),
-    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
-    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 30.0),
-    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
+    #  is_causal, window_size_left, window_size_right, softcap, dropout_p)
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 0.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 0.0, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 0.0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 0.0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 0.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 256, 30.0, 0.0),
+    (torch.bfloat16, 5, 4, 4, 1024, 1024, 128, True, -128, 864, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, False, 0, 256, 30.0, 0.0),
+    (torch.float16, 2, 2, 2, 512, 512, 128, False, 64, 128, 30.0, 0.0),
+    (torch.bfloat16, 1, 1, 1, 1, 1024, 128, True, 512, 0, 30.0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, -1, -1, 30.0, 0.0),
+    (torch.bfloat16, 2, 6, 2, 2, 1024, 128, True, 256, 0, 30.0, 0.0),
+    # Dropout
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, 512, 0, 0.0, 0.3),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right, softcap",
+    "is_causal, window_size_left, window_size_right, softcap, dropout_p",
     test_cases_bsnd_swa,
 )
 def test_fa_bsnd_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right, softcap
+    is_causal, window_size_left, window_size_right, softcap, dropout_p
 ):
     query = rand_inputs((batch_size, q_seqlen, num_heads, head_size), data_type, "npu")
     key = rand_inputs((batch_size, kv_seqlen, kv_heads, head_size), data_type, "npu")
@@ -246,32 +267,38 @@ def test_fa_bsnd_bwd_swa(
     results = run_bsnd_bwd(
         query, key, value, dout, data_type,
         num_heads, kv_heads, scale, softcap, is_causal, window_size,
+        dropout_p=dropout_p,
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen = [
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 0.0),
-    (torch.float16, 5, 5, 1, 512, 512, 128, True, 0.0),
-    (torch.float16, 5, 5, 1, 777, 888, 192, False, 0.0),
-    (torch.float16, 5, 5, 1, 1777, 1888, 256, True, 0.0),
-    (torch.bfloat16, 3, 1, 1, 7777, 8192, 64, True, 0.0),
-    (torch.bfloat16, 5, 5, 1, 711, 8192, 111, True, 0.0),
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 30.0),
-    (torch.float16, 5, 5, 1, 512, 512, 128, True, 30.0),
-    (torch.float16, 5, 5, 1, 777, 888, 192, False, 30.0),
-    (torch.float16, 5, 5, 1, 1777, 1888, 256, True, 30.0),
-    (torch.bfloat16, 3, 1, 1, 7777, 8192, 64, True, 30.0),
-    (torch.bfloat16, 5, 5, 1, 711, 8192, 111, True, 30.0),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p)
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 0.0, 0.0),
+    (torch.float16, 5, 5, 1, 512, 512, 128, True, 0.0, 0.0),
+    (torch.float16, 5, 5, 1, 777, 888, 192, False, 0.0, 0.0),
+    (torch.float16, 5, 5, 1, 1777, 1888, 256, True, 0.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 7777, 8192, 64, True, 0.0, 0.0),
+    (torch.bfloat16, 5, 5, 1, 711, 8192, 111, True, 0.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 30.0, 0.0),
+    (torch.float16, 5, 5, 1, 512, 512, 128, True, 30.0, 0.0),
+    (torch.float16, 5, 5, 1, 777, 888, 192, False, 30.0, 0.0),
+    (torch.float16, 5, 5, 1, 1777, 1888, 256, True, 30.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 7777, 8192, 64, True, 30.0, 0.0),
+    (torch.bfloat16, 5, 5, 1, 711, 8192, 111, True, 30.0, 0.0),
+    # Dropout
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 0.0, 0.3),
+    (torch.float16, 5, 5, 1, 777, 888, 128, False, 0.0, 0.2),
+    (torch.float16, 5, 5, 1, 512, 512, 128, True, 30.0, 0.5),
 ]
 
 
 @pytest.mark.parametrize(
-    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap",
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p",
     test_cases_varlen,
 )
 def test_fa_varlen_bwd(
-    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, softcap, dropout_p
 ):
     seqlens_q, seqlens_k = rand_seqlens_qk(batch_size, q_seqlen, kv_seqlen)
     max_seqlen_q = max(seqlens_q)
@@ -294,28 +321,33 @@ def test_fa_varlen_bwd(
         max_seqlen_q, max_seqlen_k,
         seqlens_q, seqlens_k,
         scale, softcap, is_causal, (-1, -1),
+        dropout_p=dropout_p,
     )
     assert_bwd_results(*results)
 
 
 test_cases_varlen_swa = [
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 512, 0, 0.0),
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, False, 0, 256, 0.0),
-    (torch.float16, 3, 2, 2, 512, 512, 128, False, 64, 128, 0.0),
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 512, 0, 30.0),
-    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, False, 0, 256, 30.0),
-    (torch.float16, 3, 2, 2, 512, 512, 128, False, 64, 128, 30.0),
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
+    #  is_causal, window_size_left, window_size_right, softcap, dropout_p)
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 512, 0, 0.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, False, 0, 256, 0.0, 0.0),
+    (torch.float16, 3, 2, 2, 512, 512, 128, False, 64, 128, 0.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 512, 0, 30.0, 0.0),
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, False, 0, 256, 30.0, 0.0),
+    (torch.float16, 3, 2, 2, 512, 512, 128, False, 64, 128, 30.0, 0.0),
+    # Dropout
+    (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, 512, 0, 0.0, 0.3),
 ]
 
 
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
-    "is_causal, window_size_left, window_size_right, softcap",
+    "is_causal, window_size_left, window_size_right, softcap, dropout_p",
     test_cases_varlen_swa,
 )
 def test_fa_varlen_bwd_swa(
     data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
-    is_causal, window_size_left, window_size_right, softcap
+    is_causal, window_size_left, window_size_right, softcap, dropout_p
 ):
     seqlens_q, seqlens_k = rand_seqlens_qk(batch_size, q_seqlen, kv_seqlen)
     max_seqlen_q = max(seqlens_q)
@@ -339,5 +371,6 @@ def test_fa_varlen_bwd_swa(
         max_seqlen_q, max_seqlen_k,
         seqlens_q, seqlens_k,
         scale, softcap, is_causal, window_size,
+        dropout_p=dropout_p,
     )
     assert_bwd_results(*results)

--- a/tests/test_flash_attn_npu_v2_metadata.py
+++ b/tests/test_flash_attn_npu_v2_metadata.py
@@ -226,8 +226,9 @@ def metadata_spy(monkeypatch):
     original = interface.get_scheduler_metadata
 
     def _spy(*args, **kwargs):
-        calls.append((args, kwargs))
-        return original(*args, **kwargs)
+        result = original(*args, **kwargs)
+        calls.append((args, kwargs, result))
+        return result
 
     monkeypatch.setattr(interface, "get_scheduler_metadata", _spy)
     return calls
@@ -498,6 +499,106 @@ def test_flash_attn_varlen_func_metadata_swa_softcap(
     )
 
 
+@pytest.mark.parametrize("dropout_p", [0.1, 0.5])
+def test_flash_attn_func_metadata_dropout(dropout_p, metadata_spy):
+    batch_size, num_heads, kv_heads = 2, 4, 2
+    q_seqlen, kv_seqlen, head_size = 256, 256, 128
+    data_type = torch.bfloat16
+    query = _rand_npu((batch_size, q_seqlen, num_heads, head_size), data_type, WIDE_RANGE)
+    key = _rand_npu((batch_size, kv_seqlen, kv_heads, head_size), data_type, WIDE_RANGE)
+    value = _rand_npu((batch_size, kv_seqlen, kv_heads, head_size), data_type, WIDE_RANGE)
+    scale = 1.0 / (head_size ** 0.5)
+
+    output_npu, softmax_lse_npu, s_dmask = flash_attn_func(
+        query,
+        key,
+        value,
+        dropout_p=dropout_p,
+        softmax_scale=scale,
+        causal=False,
+        window_size=WINDOW_SIZE,
+        return_attn_probs=True,
+    )
+    torch.npu.synchronize()
+    assert len(metadata_spy) == 1
+    meta = metadata_spy[0][2]
+
+    # AICPU tiling 的 dropout 字段已被 host 补写（scheduler-metadata 路径）
+    tiling = _tiling_from_metadata(meta, has_mask=False)
+    expected_keep = 1.0 / (1.0 - dropout_p)
+    assert abs(tiling.dropoutValue - expected_keep) < 1e-4, \
+        f"dropoutValue={tiling.dropoutValue} 期望 {expected_keep}"
+    assert tiling.dropMaskDevice != 0, "dropMaskDevice 未被补写（nullptr）"
+    assert tiling.pDevice != 0, "pDevice 未被补写（return_attn_probs 时应非空）"
+
+    # 输出正确性：drop_mask 从 S_dmask 恢复，与 ref 参考一致
+    drop_mask = (s_dmask > 0).to(torch.float32).cpu()
+    golden = torch.empty((batch_size, q_seqlen, num_heads, head_size), dtype=data_type)
+    golden_lse = torch.empty((batch_size, num_heads, q_seqlen), dtype=torch.float32)
+    query_cpu, key_cpu, value_cpu = query.cpu(), key.cpu(), value.cpu()
+    for i in range(batch_size):
+        gout, glse = ref_flash_attention(
+            query_cpu[i], key_cpu[i], value_cpu[i], scale, None, data_type, 0.0,
+            drop_mask=drop_mask[i], dropout_p=dropout_p)
+        golden[i] = gout.reshape(q_seqlen, num_heads, head_size)
+        golden_lse[i] = glse.reshape(num_heads, q_seqlen)
+    torch.testing.assert_close(output_npu.cpu(), golden, rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(softmax_lse_npu.cpu(), golden_lse, rtol=RTOL, atol=ATOL)
+
+
+def test_flash_attn_varlen_func_metadata_dropout(metadata_spy):
+    num_heads, kv_heads, head_size = 4, 1, 128
+    max_q, max_k = 512, 1024
+    data_type = torch.bfloat16
+    q_offsets = [0, 512, 812, 940]
+    kv_offsets = [0, 1024, 1536, 1792]
+    dropout_p = 0.3
+    query = _rand_npu((q_offsets[-1], num_heads, head_size), data_type, WIDE_RANGE)
+    key = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    value = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    scale = 1.0 / (head_size ** 0.5)
+
+    output_npu, lse_npu, s_dmask = flash_attn_varlen_func(
+        query,
+        key,
+        value,
+        _int32_npu(q_offsets),
+        _int32_npu(kv_offsets),
+        max_q,
+        max_k,
+        dropout_p=dropout_p,
+        softmax_scale=scale,
+        causal=False,
+        window_size=WINDOW_SIZE,
+        return_attn_probs=True,
+    )
+    torch.npu.synchronize()
+    assert len(metadata_spy) == 1
+    meta = metadata_spy[0][2]
+
+    tiling = _tiling_from_metadata(meta, has_mask=False)
+    expected_keep = 1.0 / (1.0 - dropout_p)
+    assert abs(tiling.dropoutValue - expected_keep) < 1e-4, \
+        f"dropoutValue={tiling.dropoutValue} 期望 {expected_keep}"
+    assert tiling.dropMaskDevice != 0, "dropMaskDevice 未被补写（nullptr）"
+    assert tiling.pDevice != 0, "pDevice 未被补写（return_attn_probs 时应非空）"
+
+    drop_mask = (s_dmask > 0).to(torch.float32).cpu()
+    golden = torch.empty((q_offsets[-1], num_heads, head_size), dtype=data_type)
+    golden_lse = torch.empty((num_heads, q_offsets[-1]), dtype=torch.float32)
+    query_cpu, key_cpu, value_cpu = query.cpu(), key.cpu(), value.cpu()
+    for i in range(len(q_offsets) - 1):
+        qs, qe = q_offsets[i], q_offsets[i + 1]
+        ks, ke = kv_offsets[i], kv_offsets[i + 1]
+        gout, glse = ref_flash_attention(
+            query_cpu[qs:qe], key_cpu[ks:ke], value_cpu[ks:ke], scale, None, data_type, 0.0,
+            drop_mask=drop_mask[i][:, : qe - qs, : ke - ks], dropout_p=dropout_p)
+        golden[qs:qe] = gout.reshape(qe - qs, num_heads, head_size)
+        golden_lse[:, qs:qe] = glse.reshape(num_heads, qe - qs)
+    torch.testing.assert_close(output_npu.cpu(), golden, rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(lse_npu.cpu(), golden_lse, rtol=RTOL, atol=ATOL)
+
+
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal, window_size, softcap",
     KV_CACHE_BSND_CASES,
@@ -606,6 +707,7 @@ class _FAInferTilingData(ctypes.Structure):
         ("mm2OutSize", ctypes.c_uint64), ("UpdateSize", ctypes.c_uint64),
         ("workSpaceSize", ctypes.c_uint64),
         ("scaleValue", ctypes.c_float), ("softcapValue", ctypes.c_float),
+        ("dropoutValue", ctypes.c_float),
         ("padding1", ctypes.c_uint64), ("padding2", ctypes.c_uint64),
         ("padding3", ctypes.c_uint32),
         ("windowSizeLeft", ctypes.c_int64), ("windowSizeRight", ctypes.c_int64),
@@ -614,6 +716,8 @@ class _FAInferTilingData(ctypes.Structure):
         ("flashDecodeFlag", ctypes.c_uint32),
         ("coreInfo", _CoreNode * 25),
         ("splitInfo", _SplitNode * 25),
+        ("pDevice", ctypes.c_uint64),
+        ("dropMaskDevice", ctypes.c_uint64),
     ]
 
 


### PR DESCRIPTION
## Related Issue

Closes #123 and #140.



## Summary

Adds support for `dropout` and `return_attn_probs` in flash-attention-npu v2.

- Introduces `HAS_DROPOUT` and `RETURN_SOFTMAX` template parameters.
- Returns softmax output `S_dmask`  when `return_attn_probs` is true and `p_dropout > 0.0f`.
- Implements dropout logic in both v2 forward and backward passes.
- Verifies dropout correctness in the test script using the returned `S_dmask`.



## Validation

<img width="1332" height="512" alt="image" src="https://github.com/user-attachments/assets/7610c8d9-8b62-45d6-9e22-57d1d29d331f" />
<img width="1701" height="529" alt="image" src="https://github.com/user-attachments/assets/9fbe9c32-7711-4f09-b826-f54204dd2e8b" />




## Additional Information

None.