### PR TITLE
ci: isolate container cleanup by job scope

### DIFF
--- a/.github/workflows/npu_ci.yml
+++ b/.github/workflows/npu_ci.yml
@@ -240,6 +240,7 @@ jobs:
       CI_REQUIRE_HEALTHY_NPU: ${{ matrix.require_healthy }}
       CI_NPU_MAX_TASKS: ${{ matrix.max_tasks }}
       TARGET_SHA: ${{ needs.prepare.outputs.sha }}
+      CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
     outputs:
       run_outcome: ${{ steps.run.outcome }}
     steps:
@@ -271,6 +272,7 @@ jobs:
           # clone 后: fetch base 分支最新, checkout base, merge PR head
           docker_ok=false
           if docker run --rm \
+            --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
             --network host \
             -v "$PWD:/workspace" \
             -w /workspace \
@@ -363,17 +365,10 @@ jobs:
           path: /tmp/ci_test_logs/
           retention-days: 7
 
-      - name: Kill orphaned CI containers
+      - name: Clean up this job's CI containers
         if: always()
         run: |
-          echo "cleaning up orphaned containers from image: $CI_DOCKER_IMAGE"
-          orphans=$(docker ps -q --filter "ancestor=$CI_DOCKER_IMAGE")
-          if [ -n "$orphans" ]; then
-            echo "killing orphaned containers: $orphans"
-            docker kill $orphans 2>/dev/null || true
-          else
-            echo "no orphaned containers found"
-          fi
+          bash ci/cleanup_ci_containers.sh
 
   finalize:
     name: 写最终状态

--- a/.github/workflows/npu_ci_full.yml
+++ b/.github/workflows/npu_ci_full.yml
@@ -76,6 +76,7 @@ jobs:
       CI_TEST_WORKERS: ${{ github.event.inputs.workers }}
       CI_MODE: full
       CI_REF: ${{ github.event.inputs.ref }}
+      CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
     steps:
       - name: Check arch match
         id: arch
@@ -97,6 +98,7 @@ jobs:
           git config --global --add safe.directory "$PWD"
           REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
           docker run --rm \
+            --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
             --network host \
             -v "$PWD:/workspace" \
             -w /workspace \
@@ -145,14 +147,7 @@ jobs:
           path: /tmp/ci_test_logs/
           retention-days: 7
 
-      - name: Kill orphaned CI containers
+      - name: Clean up this job's CI containers
         if: always()
         run: |
-          echo "cleaning up orphaned containers from image: $CI_DOCKER_IMAGE"
-          orphans=$(docker ps -q --filter "ancestor=$CI_DOCKER_IMAGE")
-          if [ -n "$orphans" ]; then
-            echo "killing orphaned containers: $orphans"
-            docker kill $orphans 2>/dev/null || true
-          else
-            echo "no orphaned containers found"
-          fi
+          bash ci/cleanup_ci_containers.sh

--- a/.github/workflows/npu_ci_matrix.yml
+++ b/.github/workflows/npu_ci_matrix.yml
@@ -51,6 +51,7 @@ jobs:
       CI_DOCKER_IMAGE: ${{ matrix.clone_image }}
       CI_MATRIX_MAX_JOBS: ${{ inputs.max_jobs }}
       ARCH_FILTER: ${{ matrix.arch_filter }}
+      CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
     steps:
       - name: Clone repo (docker first 3x as root, then host 3x)
         env:
@@ -65,6 +66,7 @@ jobs:
           # 容器内用 git init + fetch (不要求空目录), checkout 前用 git clean 删 untracked。
           docker_ok=false
           if docker run --rm \
+            --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
             --network host \
             -v "$PWD:/workspace" \
             -w /workspace \
@@ -123,14 +125,7 @@ jobs:
           set -euo pipefail
           bash ci/run_ci_matrix.sh
 
-      - name: Kill orphaned CI containers
+      - name: Clean up this job's CI containers
         if: always()
         run: |
-          echo "cleaning up orphaned containers from image: $CI_DOCKER_IMAGE"
-          orphans=$(docker ps -q --filter "ancestor=$CI_DOCKER_IMAGE")
-          if [ -n "$orphans" ]; then
-            echo "killing orphaned containers: $orphans"
-            docker kill $orphans 2>/dev/null || true
-          else
-            echo "no orphaned containers found"
-          fi
+          bash ci/cleanup_ci_containers.sh

--- a/ci/cleanup_ci_containers.sh
+++ b/ci/cleanup_ci_containers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Stop and remove only containers owned by the current GitHub Actions job.
+
+set -euo pipefail
+
+SCOPE="${CI_CONTAINER_SCOPE:-}"
+STOP_TIMEOUT="${CI_CONTAINER_STOP_TIMEOUT:-10}"
+
+log() { printf '[cleanup-ci-containers] %s\n' "$*"; }
+die() { printf '[cleanup-ci-containers][ERROR] %s\n' "$*" >&2; exit 1; }
+
+[ -n "$SCOPE" ] || die "CI_CONTAINER_SCOPE is required; refusing an unscoped cleanup"
+[[ "$STOP_TIMEOUT" =~ ^[0-9]+$ ]] || die "CI_CONTAINER_STOP_TIMEOUT must be a non-negative integer"
+command -v docker >/dev/null 2>&1 || die "docker not found"
+
+mapfile -t container_ids < <(
+  docker ps -aq \
+    --filter "label=com.flash-attention-npu.ci.scope=$SCOPE"
+)
+
+if [ "${#container_ids[@]}" -eq 0 ]; then
+  log "no containers found for scope=$SCOPE"
+  exit 0
+fi
+
+log "stopping ${#container_ids[@]} container(s) for scope=$SCOPE: ${container_ids[*]}"
+docker stop --time "$STOP_TIMEOUT" "${container_ids[@]}" >/dev/null 2>&1 || true
+
+# --rm normally removes stopped containers. Force-remove anything left behind.
+mapfile -t remaining_ids < <(
+  docker ps -aq \
+    --filter "label=com.flash-attention-npu.ci.scope=$SCOPE"
+)
+if [ "${#remaining_ids[@]}" -gt 0 ]; then
+  log "force-removing remaining container(s): ${remaining_ids[*]}"
+  docker rm -f "${remaining_ids[@]}" >/dev/null 2>&1 || true
+fi
+
+log "done"

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -16,6 +16,7 @@
 #   CI_DOCKER_PRIVILEGED     (默认 true)   是否带 --privileged
 #   CI_DOCKER_IMAGE          (默认 fa-npu-ci:910b-cann9.1-torch2.9)
 #   CI_SKIP_BUILD            (默认 false)  true=跳过阶段1 (已有 build/ 产物)
+#   CI_CONTAINER_SCOPE       当前 CI job 的唯一容器归属标识
 #   CI_NPU_WAIT_MAX_SEC      (默认 600)    所有卡忙时最长等待秒数
 #   CI_NPU_WAIT_INTERVAL_SEC (默认 30)     所有卡忙时重探间隔秒数
 #   ASCEND_RT_VISIBLE_DEVICES               手动指定宿主机物理卡时跳过自动选卡
@@ -31,6 +32,7 @@ CI_CONTAINER_DEVICE="${CI_CONTAINER_DEVICE:-0}"
 CI_DOCKER_PRIVILEGED="${CI_DOCKER_PRIVILEGED:-true}"
 CI_DOCKER_IMAGE="${CI_DOCKER_IMAGE:-fa-npu-ci:910b-cann9.1-torch2.9}"
 CI_SKIP_BUILD="${CI_SKIP_BUILD:-false}"
+CI_CONTAINER_SCOPE="${CI_CONTAINER_SCOPE:-local-$(id -u)-$$}"
 # 宿主机日志目录: 挂载进容器, 容器内写的日志直接落到宿主机, 避免 --rm 删除容器后日志丢失。
 # 同时让 workflow 的 upload-artifact (path: /tmp/ci_test_logs) 能读到日志。
 CI_TEST_LOG_DIR_HOST="${CI_TEST_LOG_DIR_HOST:-/tmp/ci_test_logs}"
@@ -63,26 +65,27 @@ if [ "$CI_DOCKER_PRIVILEGED" = "true" ]; then
 fi
 
 # ---------- 取消信号处理 (self-hosted runner 兜底) ----------
-# GitHub 取消 workflow 时, self-hosted runner 只杀 runner 进程, 不会停 docker 容器,
-# 导致 NPU 被孤儿容器持续占用。用 trap 捕获 SIGTERM/SIGINT, kill 当前 docker client
-# (PID), docker client 向容器主进程转发 SIGTERM, 容器退出后 --rm 自动清理。
-# 配合 workflow 的 cleanup step (if: always()) 双重兜底。
+# GitHub 取消 workflow 时, self-hosted runner 可能只停止 runner 进程, 不会停止容器。
+# 按当前 job 的 scope 清理所有本 job 容器, 配合 workflow cleanup step 双重兜底。
 CURRENT_DOCKER_PID=""
 cleanup_on_signal() {
-  log "received cancel/terminate signal, killing docker container (pid=${CURRENT_DOCKER_PID:-<none>})..."
+  log "received cancel/terminate signal, cleaning containers for scope=$CI_CONTAINER_SCOPE..."
   if [ -n "$CURRENT_DOCKER_PID" ]; then
-    kill -TERM "$CURRENT_DOCKER_PID" 2>/dev/null || true
+    kill -KILL "$CURRENT_DOCKER_PID" 2>/dev/null || true
     wait "$CURRENT_DOCKER_PID" 2>/dev/null || true
     CURRENT_DOCKER_PID=""
   fi
+  CI_CONTAINER_SCOPE="$CI_CONTAINER_SCOPE" bash "$SCRIPT_DIR/cleanup_ci_containers.sh" || true
   exit 130
 }
 trap cleanup_on_signal SIGTERM SIGINT
 
 # ---------- 阶段1: 编译 (不加锁, 不绑卡) ----------
 run_build_phase() {
+  local rc
   log "=== Phase 1: build (no NPU lock) ==="
   docker run --rm \
+    --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
     "${privileged_args[@]}" \
     --network host \
     --ipc host \
@@ -93,7 +96,13 @@ run_build_phase() {
     "$CI_DOCKER_IMAGE" \
     bash -lc 'git config --global --add safe.directory /workspace/flash-attention-npu && bash ci/run_ci_build.sh' &
   CURRENT_DOCKER_PID=$!
-  wait "$CURRENT_DOCKER_PID"
+  if wait "$CURRENT_DOCKER_PID"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  CURRENT_DOCKER_PID=""
+  return "$rc"
 }
 
 # ---------- 阶段2: 测试 (加锁 + 绑卡) ----------
@@ -105,6 +114,7 @@ get_candidates() {
 
 run_docker_test() {
   local device_id="$1"
+  local rc
   local mount_args=()
   while IFS= read -r m; do
     [ -n "$m" ] && mount_args+=("$m")
@@ -115,6 +125,7 @@ run_docker_test() {
   mkdir -p "$CI_TEST_LOG_DIR_HOST"
   chmod 777 "$CI_TEST_LOG_DIR_HOST" 2>/dev/null || true
   docker run --rm \
+    --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
     "${privileged_args[@]}" \
     --network host \
     --ipc host \
@@ -137,7 +148,13 @@ run_docker_test() {
     "$CI_DOCKER_IMAGE" \
     bash -lc 'git config --global --add safe.directory /workspace/flash-attention-npu && bash ci/run_ci_test.sh' &
   CURRENT_DOCKER_PID=$!
-  wait "$CURRENT_DOCKER_PID"
+  if wait "$CURRENT_DOCKER_PID"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  CURRENT_DOCKER_PID=""
+  return "$rc"
 }
 
 acquire_lock_and_run_test() {

--- a/ci/run_ci_matrix.sh
+++ b/ci/run_ci_matrix.sh
@@ -19,6 +19,7 @@
 #   IMAGE_PREFIX          (默认 fa-npu-ci)
 #   CI_MATRIX_MAX_JOBS    (默认 0=不限) 并发容器数上限 (内存吃紧时调小, 如 3)
 #   CI_DOCKER_PRIVILEGED  (默认 true)
+#   CI_CONTAINER_SCOPE   （默认 -local-$(id -u)-$$）当前 CI job 的唯一容器归属标识
 #   FLASH_ATTN_BUILD_VERSION (默认 all) 编译哪些 API 代 (all/v2/v3/v4)
 
 set -euo pipefail
@@ -29,13 +30,32 @@ MATRIX_FILE="${MATRIX_FILE:-$REPO_ROOT/ci/build_matrix.tsv}"
 IMAGE_PREFIX="${IMAGE_PREFIX:-fa-npu-ci}"
 CI_MATRIX_MAX_JOBS="${CI_MATRIX_MAX_JOBS:-0}"
 CI_DOCKER_PRIVILEGED="${CI_DOCKER_PRIVILEGED:-true}"
+CI_CONTAINER_SCOPE="${CI_CONTAINER_SCOPE:-local-$(id -u)-$$}"
 LOG_DIR="${REPO_ROOT}/build/matrix-logs"
+# 每个 combo 一个 docker CLI PID 文件; 取消时先终止这些客户端, 再按 scope 清理容器。
+PID_DIR="$LOG_DIR/pids"
 # 架构过滤: 非空时只跑 tsv 第 7 列 (arch) 匹配的 combo。用于多机器分架构跑:
 # 950 机器设 ARCH_FILTER=x86_64, 910B 机器设 ARCH_FILTER=aarch64, 各跑各的。
 ARCH_FILTER="${ARCH_FILTER:-}"
 
 log() { printf '[matrix-build] %s\n' "$*"; }
 die() { printf '[matrix-build][ERROR] %s\n' "$*" >&2; exit 1; }
+
+cleanup_on_signal() {
+  log "received cancel/terminate signal, stopping matrix docker clients for scope=$CI_CONTAINER_SCOPE"
+  shopt -s nullglob
+  for pidfile in "$PID_DIR"/*.pid; do
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    if [[ "$pid" =~ ^[0-9]+$ ]]; then
+      log "stopping docker client pid=$pid ($(basename "$pidfile"))"
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  done
+  CI_CONTAINER_SCOPE="$CI_CONTAINER_SCOPE" bash "$SCRIPT_DIR/cleanup_ci_containers.sh" || true
+  rm -f "$PID_DIR"/*.pid 2>/dev/null || true
+  exit 130
+}
+trap cleanup_on_signal SIGTERM SIGINT
 
 command -v docker >/dev/null 2>&1 || die "docker not found"
 [ -f "$MATRIX_FILE" ] || die "matrix file not found: $MATRIX_FILE"
@@ -75,6 +95,8 @@ combo_image() {
 }
 
 mkdir -p "$LOG_DIR"
+mkdir -p "$PID_DIR"
+find "$PID_DIR" -maxdepth 1 -type f -name '*.pid' -delete
 
 # 检查镜像是否都已构建
 missing=()
@@ -99,25 +121,41 @@ log "logs dir: $LOG_DIR"
 first_name="${COMBOS[0]%%|*}"
 first_img="$(combo_image "${COMBOS[0]}")"
 log "pre-init submodule csrc/catlass (once, via $first_img)"
+preinit_pidfile="$PID_DIR/preinit.pid"
+rm -f "$preinit_pidfile"
+set +e
 docker run --rm \
+  --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
   "${privileged_args[@]}" \
   --network host \
   -v "$REPO_ROOT:/workspace/flash-attention-npu" \
   -w /workspace/flash-attention-npu \
   "$first_img" \
-  bash -lc 'git config --global --add safe.directory "*" && git submodule update --init --recursive csrc/catlass' \
-  || die "submodule pre-init failed"
+  bash -lc 'git config --global --add safe.directory "*" && git submodule update --init --recursive csrc/catlass' &
+preinit_pid=$!
+printf '%s\n' "$preinit_pid" > "$preinit_pidfile"
+if wait "$preinit_pid"; then
+  preinit_rc=0
+else
+  preinit_rc=$?
+fi
+set -e
+rm -f "$preinit_pidfile"
+[ "$preinit_rc" -eq 0 ] || die "submodule pre-init failed"
 
 # ---------- 2. 每个 combo 一个容器, 并发编译 ----------
 build_one() {
-  local line="$1" name logf rc img
+  local line="$1" name logf rc img docker_pid pidfile
   name="${line%%|*}"
   img="$(combo_image "$line")"
   logf="$LOG_DIR/${name}.log"
+  pidfile="$PID_DIR/${name}.pid"
   : > "$logf"
+  rm -f "$pidfile"
   echo "[matrix-build] >>> $name ($img) -> $logf"
   set +e
   docker run --rm \
+    --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
     "${privileged_args[@]}" \
     --network host \
     -v "$REPO_ROOT:/workspace/flash-attention-npu" \
@@ -127,8 +165,15 @@ build_one() {
     -w /workspace/flash-attention-npu \
     "$img" \
     bash -lc 'git config --global --add safe.directory "*" && python3 setup.py build --build-base=/tmp/build' \
-    > "$logf" 2>&1
-  rc=$?
+    > "$logf" 2>&1 &
+  docker_pid=$!
+  printf '%s\n' "$docker_pid" > "$pidfile"
+  if wait "$docker_pid"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  rm -f "$pidfile"
   echo "$rc" > "$LOG_DIR/${name}.rc"
 }
 

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -1,11 +1,21 @@
 # Copyright (c) 2026, Minghua Shen.
 
-import sys
 import os
+import sys
+
+import pytest
 import torch
 import torch_npu
-import pytest
-from flash_attn_npu import flash_attn_with_kvcache, flash_attn_func, flash_attn_varlen_func
+
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("flash_attn_npu (v2) not supported on Ascend950", allow_module_level=True)
+
+from flash_attn_npu import (
+    flash_attn_func,
+    flash_attn_varlen_func,
+    flash_attn_with_kvcache,
+)
+
 
 def group_matmul(head, kv_head, left, right, high_prec = 1):
     group_num = head // kv_head

--- a/tests/test_flash_attn_npu_v2_bwd.py
+++ b/tests/test_flash_attn_npu_v2_bwd.py
@@ -20,13 +20,19 @@ import pytest
 import torch
 import torch_npu
 
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("flash_attn_npu (v2) not supported on Ascend950", allow_module_level=True)
+
 from flash_attn_npu import flash_attn_func, flash_attn_varlen_func
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 if TESTS_DIR not in sys.path:
     sys.path.insert(0, TESTS_DIR)
 
-from fa_small_op_golden import golden_bsnd_bwd_from_fwd, golden_tnd_bwd_from_fwd  # noqa: E402
+from fa_small_op_golden import (  # noqa: E402
+    golden_bsnd_bwd_from_fwd,
+    golden_tnd_bwd_from_fwd,
+)
 
 RTOL_GOLDEN = 1e-2
 ATOL_GOLDEN = 1e-2

--- a/tests/test_flash_attn_npu_v3_graph.py
+++ b/tests/test_flash_attn_npu_v3_graph.py
@@ -4,9 +4,11 @@ import pytest
 import torch
 import torch_npu
 
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("get_scheduler_metadata not on Ascend950", allow_module_level=True)
+
 from flash_attn_npu_3 import flash_attn_with_kvcache, get_scheduler_metadata
 from tests.test_flash_attn_npu_v3 import ref_flash_attention
-
 
 RTOL = 1e-2
 ATOL = 1e-2

--- a/tests/test_flash_attn_npu_v3_metadata.py
+++ b/tests/test_flash_attn_npu_v3_metadata.py
@@ -4,6 +4,9 @@ import pytest
 import torch
 import torch_npu
 
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("flash_attn_func / flash_attn_varlen_func / get_scheduler_metadata not on Ascend950", allow_module_level=True)
+
 from flash_attn_npu_3 import (
     flash_attn_func,
     flash_attn_varlen_func,
@@ -11,7 +14,6 @@ from flash_attn_npu_3 import (
     get_scheduler_metadata,
 )
 from tests.test_flash_attn_npu_v3 import ref_flash_attention
-
 
 RTOL = 1e-2
 ATOL = 1e-2


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

Fixes #150 

## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Prevent CI cleanup from terminating containers belonging to concurrent jobs that use the same Docker image.

- Add a unique `CI_CONTAINER_SCOPE` for each CI job.
- Label all CI-created containers with the job scope.
- Replace image-ancestor cleanup with scope-based cleanup.
- Add shared cleanup logic in `ci/cleanup_ci_containers.sh`.
- Track Docker client PIDs for cancellation handling.
- Handle cancellation for ordinary and matrix CI jobs.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->