### PR TITLE
add flash_attention_v4

### DIFF
--- a/csrc/ascend910/flash_attn_npu_4/fa_metadata.aicpu
+++ b/csrc/ascend910/flash_attn_npu_4/fa_metadata.aicpu
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * Modified by Minghua Shen, 2026
+ */
+
+#include "aicpu_api.h"
+#include "fa_metadata_args.h"
+#include "fa_split.h"
+#include "tilingdata.h"
+#include <cstdint>
+
+namespace {
+constexpr uint32_t Q_TILE_CEIL = 128;
+constexpr uint32_t N_SPLIT_HELPER = 2;
+
+inline uint32_t CeilDiv(uint32_t a, uint32_t b)
+{
+    return (b == 0) ? 0 : (a + b - 1) / b;
+}
+
+inline uint32_t GetQNBlockTile(uint32_t qSeqlen, uint32_t groupSize)
+{
+    uint32_t qNBlockTile = (qSeqlen != 0)
+        ? (Q_TILE_CEIL / qSeqlen) / N_SPLIT_HELPER * N_SPLIT_HELPER
+        : Q_TILE_CEIL;
+    qNBlockTile = qNBlockTile < groupSize ? qNBlockTile : groupSize;
+    qNBlockTile = qNBlockTile < 1u ? 1u : qNBlockTile;
+    return qNBlockTile;
+}
+}
+
+__global__ __aicpu__ uint32_t ComputeFAMetadata(void *args)
+{
+    FAMetadataArgs *metaArgs = reinterpret_cast<FAMetadataArgs *>(args);
+    const bool causal = metaArgs->maskType != 0;
+    FAInferTilingData *tilingData = reinterpret_cast<FAInferTilingData *>(
+        metaArgs->metaOutAddr + fa_metadata::TilingOffset(causal));
+    const int32_t *cuSeqlensQ = reinterpret_cast<const int32_t *>(metaArgs->cuSeqlensQAddr);
+    const int32_t *seqlensK = reinterpret_cast<const int32_t *>(metaArgs->seqlensKAddr);
+
+    uint8_t *tilingBytes = reinterpret_cast<uint8_t *>(tilingData);
+    for (uint64_t i = 0; i < sizeof(FAInferTilingData); ++i) {
+        tilingBytes[i] = 0;
+    }
+
+    tilingData->batch = metaArgs->batch;
+    tilingData->numHeads = metaArgs->numHeads;
+    tilingData->kvHeads = metaArgs->numHeadsK;
+    tilingData->embeddingSize = metaArgs->embeddingSize;
+    tilingData->embeddingSizeV = metaArgs->embeddingSizeV;
+    tilingData->numBlocks = metaArgs->numBlocks;
+    tilingData->blockSize = metaArgs->blockSize;
+    tilingData->maxNumBlocksPerBatch = metaArgs->maxNumBlocksPerBatch;
+    tilingData->maskType = metaArgs->maskType;
+    tilingData->scaleValue = metaArgs->scaleValue;
+    tilingData->maxQSeqlen = metaArgs->maxQSeqlen;
+    tilingData->numSplits = metaArgs->numSplits > 0u ? metaArgs->numSplits : 1u;
+
+    uint32_t maxKvSeqlen = 0;
+    if (seqlensK != nullptr) {
+        for (uint32_t batchIdx = 0; batchIdx < metaArgs->batch; ++batchIdx) {
+            uint32_t kvLen = metaArgs->isVarlenKv != 0
+                ? static_cast<uint32_t>(seqlensK[batchIdx + 1] - seqlensK[batchIdx])
+                : static_cast<uint32_t>(seqlensK[batchIdx]);
+            if (kvLen > maxKvSeqlen) {
+                maxKvSeqlen = kvLen;
+            }
+        }
+    }
+    tilingData->maxKvSeqlen = maxKvSeqlen;
+
+    const uint64_t blockDim = static_cast<uint64_t>(metaArgs->blockDim);
+    tilingData->mm1OutSize = fa_metadata::Mm1OutSize(blockDim);
+    tilingData->smOnlineOutSize = fa_metadata::SmOnlineOutSize(blockDim);
+    tilingData->mm2OutSize = fa_metadata::Mm2OutSize(blockDim);
+    tilingData->UpdateSize = fa_metadata::UpdateOutSize(blockDim);
+    tilingData->workSpaceSize = fa_metadata::WorkSpaceSize(blockDim);
+
+    const uint32_t groupSize = (metaArgs->numHeadsK == 0) ? 1u : (metaArgs->numHeads / metaArgs->numHeadsK);
+    uint32_t totalTaskNum = 0;
+    uint32_t firstBatchTaskNum = 0;
+    for (uint32_t batchIdx = 0; batchIdx < metaArgs->batch; ++batchIdx) {
+        uint32_t qSeqlen = metaArgs->maxQSeqlen;
+        if (metaArgs->isVarlen != 0) {
+            qSeqlen = static_cast<uint32_t>(cuSeqlensQ[batchIdx + 1] - cuSeqlensQ[batchIdx]);
+        }
+        const uint32_t curQNBlockTile = GetQNBlockTile(qSeqlen, groupSize);
+        const uint32_t qNBlockNumPerGroup = CeilDiv(groupSize, curQNBlockTile);
+        const uint32_t curQNBlockNum = qNBlockNumPerGroup * metaArgs->numHeadsK;
+        const uint32_t curQSBlockTile = Q_TILE_CEIL;
+        const uint32_t curQSBlockNum = CeilDiv(qSeqlen, curQSBlockTile);
+        const uint32_t curTaskNum = curQNBlockNum * curQSBlockNum;
+        if (batchIdx == 0) {
+            firstBatchTaskNum = curTaskNum;
+        }
+        totalTaskNum += curTaskNum;
+    }
+    tilingData->firstBatchTaskNum = firstBatchTaskNum;
+    tilingData->totalTaskNum = totalTaskNum;
+
+    {
+        uint32_t maxQ = 0;
+        uint32_t minQ = 0xFFFFFFFFu;
+        for (uint32_t batchIdx = 0; batchIdx < metaArgs->batch; ++batchIdx) {
+            uint32_t qLen = metaArgs->maxQSeqlen;
+            if (metaArgs->isVarlen != 0) {
+                qLen = static_cast<uint32_t>(cuSeqlensQ[batchIdx + 1] - cuSeqlensQ[batchIdx]);
+            }
+            if (qLen > maxQ) maxQ = qLen;
+            if (qLen < minQ) minQ = qLen;
+        }
+        const uint32_t bd = metaArgs->blockDim;
+        const uint32_t numTasks = metaArgs->batch * metaArgs->numHeadsK;
+        const bool isLongSeq = (static_cast<double>(numTasks) <= 0.8 * bd) && (maxKvSeqlen >= bd * 512u);
+        const bool isShortSeq = (static_cast<double>(numTasks) <= 0.4 * bd) && (maxKvSeqlen >= 1024u);
+        const bool fdFlag = (metaArgs->pagedKV != 0) && (metaArgs->isVarlen != 0) &&
+            (maxQ * groupSize <= 128u) && (maxQ <= 16u) &&
+            (maxKvSeqlen >= 1024u) && (minQ > 0u) && (isLongSeq || isShortSeq);
+        tilingData->flashDecodeFlag = fdFlag ? 1u : 0u;
+        if (fdFlag) {
+            fa_split::SplitContext ctx;
+            ctx.batch_size = static_cast<int32_t>(metaArgs->batch);
+            ctx.num_heads = static_cast<int32_t>(metaArgs->numHeads);
+            ctx.num_heads_k = static_cast<int32_t>(metaArgs->numHeadsK);
+            ctx.seqlen_q = static_cast<int32_t>(metaArgs->maxQSeqlen);
+            ctx.head_size_v = static_cast<int32_t>(metaArgs->embeddingSizeV);
+            ctx.cu_seqlen_q_cpu = const_cast<int32_t *>(cuSeqlensQ);
+            ctx.seqlens_k_cpu = const_cast<int32_t *>(seqlensK);
+            ctx.is_varlen_q = metaArgs->isVarlen != 0;
+            ctx.blockDim = bd;
+            ctx.num_splits = static_cast<int32_t>(metaArgs->numSplits);
+            fa_split::splitBN2S1GS2(tilingData, ctx);
+            tilingData->workSpaceSize = fa_metadata::WorkSpaceSize(static_cast<uint64_t>(bd))
+                + tilingData->splitLseTotalSize + tilingData->splitOTotalSize;
+        }
+    }
+
+    if (causal) {
+        int8_t *maskBase = reinterpret_cast<int8_t *>(metaArgs->metaOutAddr);
+        const uint32_t maskDim = fa_metadata::MASK_DIM;
+        for (uint32_t row = 0; row < maskDim; ++row) {
+            int8_t *maskRow = maskBase + static_cast<uint64_t>(row) * maskDim;
+            for (uint32_t col = 0; col < maskDim; ++col) {
+                maskRow[col] = (col > row) ? static_cast<int8_t>(1) : static_cast<int8_t>(0);
+            }
+        }
+    }
+
+    AscendC::DataStoreBarrier();
+    return 0;
+}

--- a/csrc/ascend910/flash_attn_npu_4/fa_metadata_args.h
+++ b/csrc/ascend910/flash_attn_npu_4/fa_metadata_args.h
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * Modified by Minghua Shen, 2026
+ */
+
+#ifndef FA_METADATA_ARGS_H
+#define FA_METADATA_ARGS_H
+
+#include <cstdint>
+#include "tilingdata.h"
+
+namespace fa_metadata {
+constexpr uint32_t MASK_DIM = 2048;
+constexpr uint64_t MASK_BYTES = static_cast<uint64_t>(MASK_DIM) * MASK_DIM;
+
+inline uint64_t TilingOffset(bool causal) { return causal ? MASK_BYTES : 0; }
+inline uint64_t MetadataBytes(bool causal) { return TilingOffset(causal) + sizeof(FAInferTilingData); }
+
+constexpr uint64_t WORKSPACE_BLOCK_SIZE_DB = static_cast<uint64_t>(128) * 512;
+constexpr uint64_t PRELAUNCH_NUM = 3;
+inline uint64_t Mm1OutSize(uint64_t blockDim) { return blockDim * WORKSPACE_BLOCK_SIZE_DB * 4 * PRELAUNCH_NUM; }
+inline uint64_t SmOnlineOutSize(uint64_t blockDim) { return blockDim * WORKSPACE_BLOCK_SIZE_DB * 2 * PRELAUNCH_NUM; }
+inline uint64_t Mm2OutSize(uint64_t blockDim) { return blockDim * WORKSPACE_BLOCK_SIZE_DB * 4 * PRELAUNCH_NUM; }
+inline uint64_t UpdateOutSize(uint64_t blockDim) { return blockDim * WORKSPACE_BLOCK_SIZE_DB * 4 * PRELAUNCH_NUM; }
+inline uint64_t WorkSpaceSize(uint64_t blockDim)
+{
+    return Mm1OutSize(blockDim) + SmOnlineOutSize(blockDim) + Mm2OutSize(blockDim) + UpdateOutSize(blockDim);
+}
+}
+
+struct FAMetadataArgs {
+    uint64_t cuSeqlensQAddr;
+    uint64_t seqlensKAddr;
+    uint64_t metaOutAddr;
+    uint32_t batch;
+    uint32_t numHeads;
+    uint32_t numHeadsK;
+    uint32_t embeddingSize;
+    uint32_t embeddingSizeV;
+    uint32_t numBlocks;
+    uint32_t blockSize;
+    uint32_t maxNumBlocksPerBatch;
+    uint32_t maxQSeqlen;
+    uint32_t maskType;
+    uint32_t blockDim;
+    uint32_t isVarlen;
+    uint32_t isVarlenKv;
+    uint32_t pagedKV;
+    uint32_t numSplits;
+    float scaleValue;
+};
+
+#endif

--- a/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
@@ -32,7 +32,28 @@ using namespace KernelCommon;
 #include "bwd_dispatch.hpp"
 #include <cmath>
 
+#include "fa_metadata_args.h"
+
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+
+extern __global__ __aicpu__ uint32_t ComputeFAMetadata(void *args);
+
+#define ACL_CHECK(expr) TORCH_CHECK((expr) == ACL_SUCCESS, #expr " failed")
+
+static at::Tensor GetSchedulerMetadataImpl(FAMetadataArgs args)
+{
+    const int64_t bytes = static_cast<int64_t>(fa_metadata::MetadataBytes(args.maskType != 0));
+    at::Tensor meta = at::empty({bytes}, at::device(at::kPrivateUse1).dtype(at::kByte));
+    args.metaOutAddr = reinterpret_cast<uint64_t>(meta.data_ptr());
+
+    aclrtStream aicpuStream = c10_npu::getNPUStreamFromPool().stream(false);
+    static thread_local FAMetadataArgs metaArgs;
+    metaArgs = args;
+
+    ComputeFAMetadata<<<1, nullptr, aicpuStream>>>(&metaArgs, sizeof(metaArgs));
+    ACL_CHECK(aclrtSynchronizeStream(aicpuStream));
+    return meta;
+}
 
 std::vector<at::Tensor>
 mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
@@ -57,7 +78,8 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         float softcap,
         int64_t num_splits,
         std::optional<bool> pack_gqa_,
-        std::optional<at::Tensor> learnable_sink_
+        std::optional<at::Tensor> learnable_sink_,
+        std::optional<at::Tensor> scheduler_metadata_
         )
 {
     const c10::OptionalDeviceGuard device_guard(device_of(q));
@@ -180,6 +202,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     uint8_t *maskDevice = nullptr;
     bool flashDecodeFlag = false;
     bool is_local = false;
+    bool has_softcap = (softcap > 0.0f);
 
     at::Tensor softmaxlse = at::empty({batch_size, num_heads, seqlen_q}, at::device(at::kPrivateUse1).dtype(at::kFloat));
     if (is_varlen_q) {
@@ -187,7 +210,27 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     }
     softmaxlse.fill_(std::numeric_limits<float>::infinity());
 
-
+    if (scheduler_metadata_.has_value()) {
+        auto schedMd = scheduler_metadata_.value();
+        TORCH_CHECK(schedMd.dtype() == at::kByte, "scheduler_metadata must be a byte tensor");
+        TORCH_CHECK(schedMd.is_contiguous(), "scheduler_metadata must be contiguous");
+        TORCH_CHECK(schedMd.device().type() == at::kPrivateUse1, "scheduler_metadata must be an NPU tensor");
+        TORCH_CHECK(static_cast<uint64_t>(schedMd.nbytes()) >= fa_metadata::MetadataBytes(is_causal),
+                    "scheduler_metadata buffer is too small for this call's causal flag");
+        auto metaBase = static_cast<uint8_t *>(schedMd.data_ptr());
+        tilingDevice = metaBase + fa_metadata::TilingOffset(is_causal);
+        maskDevice = is_causal ? metaBase : nullptr;
+        int64_t wsBase = static_cast<int64_t>(fa_metadata::WorkSpaceSize(blockDim));
+        int64_t wsSplit = 0;
+        if (paged_KV && is_varlen_q) {
+            int64_t maxKvUpper = static_cast<int64_t>(max_num_blocks_per_seq) * page_block_size;
+            int64_t kvSegUpper = maxKvUpper / 512 + 1;
+            int64_t lseTasksUpper = static_cast<int64_t>(num_heads) * seqlen_q * kvSegUpper * 2;
+            wsSplit = lseTasksUpper * 4 + lseTasksUpper * head_size_og * 4;
+        }
+        workspace_tensor = at::empty({wsBase + wsSplit}, at::device(at::kPrivateUse1).dtype(at::kByte));
+        launchBlockDim = blockDim;
+    } else {
         at::Tensor tiling_cpu_tensor = at::empty({static_cast<int64_t>(sizeof(FAInferTilingData))}, at::device(c10::kCPU).dtype(at::kByte));
         FAInferTilingData* tiling_cpu_ptr = reinterpret_cast<FAInferTilingData*>(tiling_cpu_tensor.data_ptr<uint8_t>());
         std::memset(tiling_cpu_ptr, 0, sizeof(FAInferTilingData));
@@ -208,7 +251,6 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         tiling_cpu_ptr->set_numBlocks(static_cast<uint32_t>(num_blocks));
         tiling_cpu_ptr->set_blockSize(static_cast<uint32_t>(page_block_size));
         tiling_cpu_ptr->set_maxNumBlocksPerBatch(static_cast<uint32_t>(max_num_blocks_per_seq));
-        bool has_softcap = (softcap > 0.0f);
         if (has_softcap) {
             tiling_cpu_ptr->set_scaleValue(softmax_scale / softcap);
         } else {
@@ -372,6 +414,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         tiling_gpu_tensor = tiling_cpu_tensor.to(at::Device(at::kPrivateUse1));
         tilingDevice = static_cast<uint8_t *>(tiling_gpu_tensor.data_ptr());
         maskDevice = (is_causal || is_local) ? static_cast<uint8_t *>(mask_gpu_tensor.data_ptr()) : nullptr;
+    }
 
     at::Tensor seqlenk_gpu_tensor;
     at::Tensor seqlenq_gpu_tensor;
@@ -431,6 +474,69 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         launch_fwd<false>(fwd_args);
     }
     return {out, softmaxlse};
+}
+
+at::Tensor get_scheduler_metadata(
+        int64_t batch_size,
+        int64_t max_seqlen_q,
+        int64_t max_seqlen_k,
+        int64_t num_heads_q,
+        int64_t num_heads_kv,
+        int64_t headdim,
+        int64_t headdim_v,
+        pybind11::object qkv_dtype,
+        at::Tensor cache_seqlens,
+        std::optional<at::Tensor> cu_seqlens_q,
+        std::optional<at::Tensor> cu_seqlens_k,
+        std::optional<at::Tensor> cu_seqlens_k_new,
+        std::optional<at::Tensor> seqused_q,
+        std::optional<at::Tensor> cache_leftpad,
+        std::optional<int64_t> page_size,
+        int64_t max_seqlen_k_new,
+        bool causal,
+        int64_t window_size_left,
+        int64_t window_size_right,
+        int64_t num_splits)
+{
+    const c10::OptionalDeviceGuard device_guard(device_of(cache_seqlens));
+    const bool is_varlen_q = cu_seqlens_q.has_value();
+    void *cuSeqlensQDev = nullptr;
+    if (is_varlen_q) {
+        auto cu_q = cu_seqlens_q.value();
+        TORCH_CHECK(cu_q.dtype() == torch::kInt32, "cu_seqlens_q must have dtype int32");
+        cuSeqlensQDev = cu_q.data_ptr();
+    }
+    TORCH_CHECK(cache_seqlens.dtype() == torch::kInt32, "cache_seqlens must have dtype int32");
+    const bool is_varlen_kv = cu_seqlens_k.has_value();
+    const uint32_t ps = page_size.has_value() ? static_cast<uint32_t>(page_size.value()) : 128;
+    const uint32_t blockDim = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAic();
+    TORCH_CHECK(num_splits >= 0 && num_splits <= static_cast<int64_t>(blockDim),
+                "NPU FlashAttention supports num_splits in [0, ", blockDim,
+                "] (0 = auto; upper bound = number of AI cores). ");
+    TORCH_CHECK(num_splits <= 1 || (page_size.has_value() && is_varlen_q),
+                "NPU FlashAttention num_splits>1 currently requires paged KV cache and varlen-q (TND) layout");
+    FAMetadataArgs args;
+    args.cuSeqlensQAddr = is_varlen_q ? reinterpret_cast<uint64_t>(cuSeqlensQDev) : 0ULL;
+    args.seqlensKAddr = reinterpret_cast<uint64_t>(cache_seqlens.data_ptr());
+    args.metaOutAddr = 0;  // set by GetSchedulerMetadataImpl
+    args.batch = static_cast<uint32_t>(batch_size);
+    args.numHeads = static_cast<uint32_t>(num_heads_q);
+    args.numHeadsK = static_cast<uint32_t>(num_heads_kv);
+    args.embeddingSize = static_cast<uint32_t>(headdim);
+    args.embeddingSizeV = static_cast<uint32_t>(headdim_v);
+    args.numBlocks = 0;
+    args.blockSize = ps;
+    args.maxNumBlocksPerBatch = page_size.has_value()
+        ? ((static_cast<uint32_t>(max_seqlen_k) + ps - 1) / ps) : 0;
+    args.maxQSeqlen = static_cast<uint32_t>(max_seqlen_q);
+    args.maskType = causal ? 1U : 0U;
+    args.blockDim = blockDim;
+    args.isVarlen = is_varlen_q ? 1U : 0U;
+    args.isVarlenKv = is_varlen_kv ? 1U : 0U;
+    args.pagedKV = page_size.has_value() ? 1U : 0U;
+    args.numSplits = static_cast<uint32_t>(num_splits);
+    args.scaleValue = 1.0f / std::sqrt(static_cast<float>(headdim));
+    return GetSchedulerMetadataImpl(args);
 }
 
 std::vector<at::Tensor>
@@ -704,4 +810,5 @@ PYBIND11_MODULE(flash_attn_npu_4, m)
     m.doc() = "FlashAttention";
     m.def("fwd", &mha_fwd, "Forward pass, with KV-cache");
     m.def("bwd", &mha_bwd, "Backward pass");
+    m.def("get_scheduler_metadata", &get_scheduler_metadata, "Precompute scheduler metadata (tiling + mask) on AICPU");
 }

--- a/flash_attn_npu_4/__init__.py
+++ b/flash_attn_npu_4/__init__.py
@@ -16,7 +16,11 @@ def is_ascend950() -> bool:
 
 
 if is_ascend910():
-    from .flash_attn_npu_interface import flash_attn_varlen_func
+    from .flash_attn_npu_interface import (
+        flash_attn_func,
+        flash_attn_varlen_func,
+        get_scheduler_metadata,
+    )
 elif is_ascend950():
     from .flash_attn_npu_interface_950 import flash_attn_varlen_func
 else:

--- a/flash_attn_npu_4/flash_attn_npu_interface.py
+++ b/flash_attn_npu_4/flash_attn_npu_interface.py
@@ -99,6 +99,7 @@ def _flash_attn_forward(
     num_splits: int = 1,
     pack_gqa: Optional[bool] = None,
     learnable_sink: Optional[torch.Tensor] = None,
+    scheduler_metadata: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     q, k = [maybe_contiguous(x) for x in (q, k)]
     v = v.contiguous() if v.stride(-1) != 1 and v.stride(-3) != 1 else v
@@ -130,6 +131,7 @@ def _flash_attn_forward(
         num_splits,
         pack_gqa,
         learnable_sink,
+        scheduler_metadata,
     )
     return out, softmax_lse
 
@@ -334,7 +336,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         aux_tensors=None,
         aux_scalars=None,
         return_lse=False,
-    ):  
+        scheduler_metadata=None,
+        seqlen_k_per_split=None,
+        disable_scheduler_metadata=False,
+    ):
         assert k.stride(-1) == 1, "k_cache must have contiguous last dimension"
         assert v.stride(-1) == 1, "v_cache must have contiguous last dimension"
         if softmax_scale is None:
@@ -368,6 +373,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             num_splits=num_splits,
             pack_gqa=pack_gqa,
             learnable_sink=learnable_sink,
+            scheduler_metadata=None if disable_scheduler_metadata else scheduler_metadata,
         )
 
         ctx.save_for_backward(
@@ -477,6 +483,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             None,  # aux_tensors
             None,  # aux_scalars
             None,  # return_lse
+            None,  # scheduler_metadata
+            None,  # seqlen_k_per_split
+            None,  # disable_scheduler_metadata
         )
 
 
@@ -501,7 +510,7 @@ def flash_attn_varlen_func(
     softcap=0.0, # 0.0 means deactivated
     num_splits=0,    # Can be tuned for speed
     pack_gqa=None,   # Can be tuned for speed
-    deterministic:bool = False, 
+    deterministic:bool = False,
     score_mod=None,
     score_mod_bwd=None,
     mask_mod=None,
@@ -509,6 +518,9 @@ def flash_attn_varlen_func(
     aux_tensors: Optional[list] = None,
     aux_scalars: Optional[tuple] = None,
     return_lse: bool = False,
+    scheduler_metadata = None,
+    seqlen_k_per_split: Optional[int] = None,
+    disable_scheduler_metadata: bool = False,
 ):
     """
     FlashAttention for variable-length sequences with optional paged KV cache.
@@ -608,7 +620,7 @@ def flash_attn_varlen_func(
         softcap, # 0.0 means deactivated
         num_splits,    # Can be tuned for speed
         pack_gqa,   # Can be tuned for speed
-        deterministic, 
+        deterministic,
         score_mod,
         score_mod_bwd,
         mask_mod,
@@ -616,4 +628,157 @@ def flash_attn_varlen_func(
         aux_tensors,
         aux_scalars,
         return_lse,
+        scheduler_metadata,
+        seqlen_k_per_split,
+        disable_scheduler_metadata,
     )
+
+def flash_attn_func(
+    q,
+    k,
+    v,
+    qv= None,
+    gather_kv_indices=None,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    learnable_sink= None,
+    softcap=0.0,
+    num_splits=1,
+    pack_gqa=None,
+    deterministic=False,
+    score_mod= None,
+    score_mod_bwd= None,
+    mask_mod= None,
+    aux_tensors= None,
+    aux_scalars= None,
+    block_sparse_tensors=None,
+    block_sparse_tensors_bwd=None,
+    return_lse=False,
+    scheduler_metadata=None,
+):
+    """dropout_p should be set to 0.0 during evaluation
+    Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
+    than Q. Note that the number of heads in Q must be divisible by the number of heads in KV.
+
+    Arguments:
+        q: (batch_size, seqlen, nheads, headdim)
+        k: (batch_size, seqlen, nheads_k, headdim)
+        v: (batch_size, seqlen, nheads_k, headdim)
+        softmax_scale: float. The scaling of QK^T before applying softmax.
+            Default to 1 / sqrt(headdim).
+        causal: bool. Whether to apply causal attention mask.
+        window_size: (left, right). If not (-1, -1), implements sliding window local attention.
+        return_lse: bool. Whether to return the logsumexp of the attention scores.
+        scheduler_metadata: Precomputed metadata blob for faster kernel launch.
+    Return:
+        out: (batch_size, seqlen, nheads, headdim).
+        softmax_lse [optional, if return_lse=True]: (batch_size, nheads, seqlen).
+    """
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+    out, softmax_lse = _flash_attn_forward(
+        q,
+        k,
+        v,
+        qv=qv,
+        out_=None,
+        cu_seqlens_q=None,
+        cu_seqlens_k=None,
+        seqused_q=None,
+        seqused_k=None,
+        max_seqlen_q=None,
+        max_seqlen_k=None,
+        min_seqlen_k=None,
+        page_table=None,
+        gather_kv_indices=gather_kv_indices,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=window_size[0],
+        window_size_right=window_size[1],
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        learnable_sink=learnable_sink,
+        scheduler_metadata=scheduler_metadata,
+    )
+    return (out, softmax_lse) if return_lse else out
+
+
+def get_scheduler_metadata(
+    batch_size,
+    max_seqlen_q,
+    max_seqlen_k,
+    num_heads_q,
+    num_heads_kv,
+    headdim,
+    headdim_v=None,
+    qkv_dtype=torch.bfloat16,
+    cache_seqlens=None,
+    cu_seqlens_q=None,
+    cu_seqlens_k=None,
+    cu_seqlens_k_new=None,
+    seqused_q=None,
+    cache_leftpad=None,
+    page_size=None,
+    max_seqlen_k_new=0,
+    causal=False,
+    window_size=(-1, -1),
+    num_splits=0,
+):
+    """Precompute scheduler metadata (tiling + mask) on AICPU.
+
+    The returned byte tensor can be passed as scheduler_metadata to
+    flash_attn_func / flash_attn_varlen_func
+    to skip host-side tiling and mask generation.
+
+    Arguments:
+        batch_size: number of sequences in the batch.
+        max_seqlen_q: maximum query sequence length.
+        max_seqlen_k: maximum key/value sequence length.
+        num_heads_q: number of query heads.
+        num_heads_kv: number of key/value heads (for MQA/GQA).
+        headdim: dimension per head (Q and K).
+        headdim_v: dimension per head for V (defaults to headdim).
+        qkv_dtype: data type (torch.bfloat16 or torch.float16).
+        cache_seqlens: (batch_size,) int32 tensor with KV cache lengths.
+        cu_seqlens_q: (batch_size+1,) int32 cumulative query sequence lengths
+            for varlen (TND) layout.
+        cu_seqlens_k: (batch_size+1,) int32 cumulative key sequence lengths
+            for varlen KV.
+        page_size: block size for paged KV cache.
+        max_seqlen_k_new: max new key sequence length (unused, reserved).
+        causal: whether to use causal attention mask.
+        window_size: (left, right) sliding window. (-1, -1) disables.
+        num_splits: number of KV splits for flash decode (0 = auto).
+
+    Returns:
+        scheduler_metadata: byte tensor containing the precomputed metadata.
+    """
+    assert cache_seqlens is not None, "cache_seqlens is required"
+    cache_seqlens = maybe_contiguous(cache_seqlens)
+    if headdim_v is None:
+        headdim_v = headdim
+    scheduler_metadata = flash_attn_npu_4.get_scheduler_metadata(
+        batch_size,
+        max_seqlen_q,
+        max_seqlen_k,
+        num_heads_q,
+        num_heads_kv,
+        headdim,
+        headdim_v,
+        qkv_dtype,
+        cache_seqlens,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        cu_seqlens_k_new,
+        seqused_q,
+        cache_leftpad,
+        page_size,
+        max_seqlen_k_new,
+        causal,
+        window_size[0],
+        window_size[1],
+        num_splits,
+    )
+    return scheduler_metadata

--- a/setup.py
+++ b/setup.py
@@ -276,8 +276,8 @@ class BishengBuildExt(build_ext):
 
     def _build_aicpu_metadata(self, ext_fullpath, ext_name):
         """Compile fa_metadata.aicpu (host AICPU object) for the ascend910
-        extensions that carry the scheduler-metadata feature (v2 and v3). This
-        is a separate `bisheng -x aicpu` invocation (host CPU code
+        extensions that carry the scheduler-metadata feature (v2, v3 and v4).
+        This is a separate `bisheng -x aicpu` invocation (host CPU code
         cross-compiled with hcc, not ASC device code); the resulting object is
         linked into the extension alongside the ASC device objects. Returns the
         .o path, or None if there is no aicpu source."""
@@ -285,6 +285,7 @@ class BishengBuildExt(build_ext):
         aicpu_src_dirs = {
             "flash_attn_npu.flash_attn_npu": os.path.join(this_dir, "csrc/ascend910", "flash_attn_npu"),
             "flash_attn_npu_3.flash_attn_npu_3": os.path.join(this_dir, "csrc/ascend910", "flash_attn_npu_3"),
+            "flash_attn_npu_4.flash_attn_npu_4": os.path.join(this_dir, "csrc/ascend910", "flash_attn_npu_4"),
         }
         src_dir = aicpu_src_dirs.get(ext_name)
         if src_dir is None:

--- a/tests/test_flash_attn_npu_v4.py
+++ b/tests/test_flash_attn_npu_v4.py
@@ -3,6 +3,7 @@
 import torch
 import torch_npu
 import pytest
+
 from tests.common.attention_ref import ref_flash_attention, ref_flash_attention_pair
 from tests.common.compare import assert_fa_close
 from tests.common.test_utils import (
@@ -19,7 +20,7 @@ from tests.common.test_utils import (
 if "Ascend950" in torch_npu.npu.get_device_name():
     from flash_attn_npu_4 import flash_attn_varlen_func
 else:
-    from flash_attn_npu_4 import flash_attn_varlen_func
+    from flash_attn_npu_4 import flash_attn_func, flash_attn_varlen_func
 
 def build_cann_causal_mask():
     """Fixed [2048, 2048] causal mask for npu_fused_infer_attention_score."""
@@ -634,3 +635,86 @@ def test_fa_kvcache_ops_with_hd_le_256(data_type, batch_size, num_heads, kv_head
     if "Ascend910" in name:
         pytest.skip("Sq > Sk not support in Ascend910")
     test_fa_kvcache_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, cache_mode, block_size, is_causal, layout, is_varied, window_size_left, window_size_right, num_splits)
+
+
+# ============================================================================
+# flash_attn_func tests (BSND layout only, 910 only)
+# ============================================================================
+
+test_cases_fa_func = [
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, is_causal, window_size_left, window_size_right, softcap)
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, False, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.float16, 7, 5, 1, 777, 888, 192, False, -1, -1, 0.0),
+    # SWA (window_size covers full sequence)
+    (torch.bfloat16, 1, 1, 1, 512, 512, 128, True, 512, 0, 0.0),
+    # MHA + GQA + MQA
+    (torch.bfloat16, 2, 8, 8, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.bfloat16, 2, 8, 2, 512, 512, 128, False, -1, -1, 0.0),
+    (torch.bfloat16, 2, 4, 1, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.float16, 2, 8, 8, 256, 256, 128, False, -1, -1, 0.0),
+    (torch.float16, 2, 8, 2, 512, 512, 128, True, -1, -1, 0.0),
+    (torch.float16, 2, 4, 1, 256, 256, 128, False, -1, -1, 0.0),
+    # head_size=64
+    (torch.bfloat16, 2, 16, 16, 512, 512, 64, True, -1, -1, 0.0),
+    (torch.float16, 2, 4, 1, 256, 256, 64, True, -1, -1, 0.0),
+]
+
+
+@pytest.mark.parametrize(
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, "
+    "is_causal, window_size_left, window_size_right, softcap",
+    test_cases_fa_func,
+)
+def test_fa_func_custom_ops(
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size,
+    is_causal, window_size_left, window_size_right, softcap,
+):
+    name = torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""
+    if "Ascend910" not in name:
+        pytest.skip("flash_attn_func only supports Ascend910")
+
+    q_min_range = -5.0
+    q_max_range = 5.0
+    kv_min_range = -5.0
+    kv_max_range = 5.0
+
+    query = (q_min_range + (q_max_range - q_min_range) * torch.rand(batch_size, q_seqlen, num_heads, head_size)).to(data_type).npu()
+    key_cache = (kv_min_range + (kv_max_range - kv_min_range) * torch.rand(batch_size, kv_seqlen, kv_heads, head_size)).to(data_type).npu()
+    value_cache = (kv_min_range + (kv_max_range - kv_min_range) * torch.rand(batch_size, kv_seqlen, kv_heads, head_size)).to(data_type).npu()
+    scale = 1.0 / (head_size ** 0.5)
+
+    ret = flash_attn_func(
+        query,
+        key_cache,
+        value_cache,
+        softmax_scale=scale,
+        causal=is_causal,
+        window_size=(window_size_left, window_size_right),
+        softcap=softcap,
+        return_lse=True,
+    )
+    out_out, softmax_lse = ret
+
+    golden_out_ref = torch.empty((batch_size, q_seqlen, num_heads, head_size), dtype=data_type)
+    golden_out_pt = torch.empty((batch_size, q_seqlen, num_heads, head_size), dtype=data_type)
+    golden_lseL_ref = torch.empty((batch_size, num_heads, q_seqlen), dtype=torch.float32)
+    golden_lseL_pt = torch.empty((batch_size, num_heads, q_seqlen), dtype=torch.float32)
+    atten_mask = None
+    if is_causal:
+        atten_mask = build_cann_causal_mask()[:q_seqlen, :kv_seqlen]
+    for i in range(batch_size):
+        key_cache_per_batch = key_cache.detach().cpu()[i:i+1]
+        value_cache_per_batch = value_cache.detach().cpu()[i:i+1]
+        query_cpu = query.detach().cpu()[i:i+1]
+        out_ref, lse_ref, out_pt, lse_pt = ref_flash_attention_pair(
+            query_cpu, key_cache_per_batch, value_cache_per_batch,
+            scale, atten_mask, data_type, softcap=softcap,
+        )
+        golden_out_ref[i:i + 1] = out_ref.reshape(1, q_seqlen, num_heads, head_size)
+        golden_out_pt[i:i + 1] = out_pt.reshape(1, q_seqlen, num_heads, head_size)
+        golden_lseL_ref[i:i + 1] = lse_ref.reshape(1, num_heads, q_seqlen)
+        golden_lseL_pt[i:i + 1] = lse_pt.reshape(1, num_heads, q_seqlen)
+
+    assert_fa_close(out_out, golden_out_ref, golden_out_pt, softcap=softcap, name="out")
+    assert_fa_close(softmax_lse, golden_lseL_ref, golden_lseL_pt, softcap=softcap, name="softmax_lse")

--- a/tests/test_flash_attn_npu_v4_graph.py
+++ b/tests/test_flash_attn_npu_v4_graph.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, Minghua Shen.
+
+import pytest
+import torch
+import torch_npu
+
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("flash_attn_func graph only on Ascend910", allow_module_level=True)
+
+from flash_attn_npu_4 import flash_attn_func, flash_attn_varlen_func, get_scheduler_metadata
+from tests.test_flash_attn_npu_v4 import ref_flash_attention, build_cann_causal_mask
+
+RTOL = 1e-2
+ATOL = 1e-2
+DATA_TYPE = torch.bfloat16
+BATCH_SIZE = 2
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+Q_SEQLEN = 128
+KV_SEQLEN = 128
+HEAD_SIZE = 128
+SCALE = 1.0 / (HEAD_SIZE ** 0.5)
+WINDOW_SIZE = (-1, -1)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_npu():
+    """Clean up NPU state between tests to avoid graph-mode state leaks."""
+    yield
+    torch.npu.synchronize()
+    torch.npu.empty_cache()
+
+
+def _rand_npu(shape, dtype=DATA_TYPE):
+    return (2 * torch.rand(shape) - 1).to(dtype).npu()
+
+
+# ==============================================================================
+# flash_attn_func graph tests
+# ==============================================================================
+
+
+@pytest.mark.parametrize("is_causal", [False, True])
+def test_flash_attn_func_graph_with_metadata(is_causal):
+    """Graph replay with precomputed scheduler_metadata for flash_attn_func."""
+
+    query = _rand_npu((BATCH_SIZE, Q_SEQLEN, NUM_HEADS, HEAD_SIZE))
+    key_cache = _rand_npu((BATCH_SIZE, KV_SEQLEN, NUM_KV_HEADS, HEAD_SIZE))
+    value_cache = _rand_npu((BATCH_SIZE, KV_SEQLEN, NUM_KV_HEADS, HEAD_SIZE))
+
+    cache_seqlens = torch.full((BATCH_SIZE,), KV_SEQLEN, dtype=torch.int32).npu()
+    scheduler_metadata = get_scheduler_metadata(
+        batch_size=BATCH_SIZE,
+        max_seqlen_q=Q_SEQLEN,
+        max_seqlen_k=KV_SEQLEN,
+        num_heads_q=NUM_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        headdim=HEAD_SIZE,
+        qkv_dtype=DATA_TYPE,
+        cache_seqlens=cache_seqlens,
+        causal=is_causal,
+        window_size=WINDOW_SIZE,
+    )
+
+    # golden
+    atten_mask = None
+    if is_causal:
+        atten_mask = build_cann_causal_mask()[:Q_SEQLEN, :KV_SEQLEN]
+    golden_out = torch.empty((BATCH_SIZE, Q_SEQLEN, NUM_HEADS, HEAD_SIZE), dtype=DATA_TYPE)
+    for i in range(BATCH_SIZE):
+        query_cpu = query.detach().cpu()[i:i+1]
+        key_cpu = key_cache.detach().cpu()[i:i+1]
+        value_cpu = value_cache.detach().cpu()[i:i+1]
+        output, _ = ref_flash_attention(
+            query_cpu, key_cpu, value_cpu,
+            SCALE, atten_mask, DATA_TYPE, softcap=0.0,
+        )
+        golden_out[i:i + 1] = output.reshape(Q_SEQLEN, NUM_HEADS, HEAD_SIZE)
+
+    # warm-up
+    flash_attn_func(
+        query, key_cache, value_cache,
+        softmax_scale=SCALE, causal=is_causal,
+        window_size=WINDOW_SIZE, scheduler_metadata=scheduler_metadata,
+        return_lse=False,
+    )
+    torch.npu.synchronize()
+
+    # graph capture
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        output_npu = flash_attn_func(
+            query, key_cache, value_cache,
+            softmax_scale=SCALE, causal=is_causal,
+            window_size=WINDOW_SIZE, scheduler_metadata=scheduler_metadata,
+            return_lse=False,
+        )
+
+    graph.replay()
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(output_npu.cpu(), golden_out, rtol=RTOL, atol=ATOL)
+    del graph
+
+
+# ==============================================================================
+# flash_attn_varlen_func graph tests (TND layout)
+# ==============================================================================
+
+VARLEN_BATCH_SIZE = 2
+VARLEN_NUM_HEADS = 4
+VARLEN_NUM_KV_HEADS = 2
+VARLEN_Q_SEQLEN = 128
+VARLEN_KV_SEQLEN = 128
+VARLEN_HEAD_SIZE = 128
+VARLEN_SCALE = 1.0 / (VARLEN_HEAD_SIZE ** 0.5)
+
+
+@pytest.mark.parametrize("is_causal", [False, True])
+def test_flash_attn_varlen_func_graph_with_metadata(is_causal):
+    """Graph replay with precomputed scheduler_metadata for flash_attn_varlen_func (TND)."""
+
+    q_sequences = [VARLEN_Q_SEQLEN] * VARLEN_BATCH_SIZE
+    kv_sequences = [VARLEN_KV_SEQLEN] * VARLEN_BATCH_SIZE
+    t_q = sum(q_sequences)
+    t_kv = sum(kv_sequences)
+
+    query = _rand_npu((t_q, VARLEN_NUM_HEADS, VARLEN_HEAD_SIZE))
+    key_cache = _rand_npu((t_kv, VARLEN_NUM_KV_HEADS, VARLEN_HEAD_SIZE))
+    value_cache = _rand_npu((t_kv, VARLEN_NUM_KV_HEADS, VARLEN_HEAD_SIZE))
+
+    cu_seqlens_q = torch.tensor([0] + [sum(q_sequences[:i + 1]) for i in range(VARLEN_BATCH_SIZE)], dtype=torch.int32).npu()
+    cu_seqlens_k = torch.tensor([0] + [sum(kv_sequences[:i + 1]) for i in range(VARLEN_BATCH_SIZE)], dtype=torch.int32).npu()
+    cache_seqlens = torch.tensor(kv_sequences, dtype=torch.int32).npu()
+
+    scheduler_metadata = get_scheduler_metadata(
+        batch_size=VARLEN_BATCH_SIZE,
+        max_seqlen_q=VARLEN_Q_SEQLEN,
+        max_seqlen_k=VARLEN_KV_SEQLEN,
+        num_heads_q=VARLEN_NUM_HEADS,
+        num_heads_kv=VARLEN_NUM_KV_HEADS,
+        headdim=VARLEN_HEAD_SIZE,
+        qkv_dtype=DATA_TYPE,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        causal=is_causal,
+        window_size=WINDOW_SIZE,
+    )
+    # golden
+    atten_mask = None
+    if is_causal:
+        atten_mask = build_cann_causal_mask()[:VARLEN_Q_SEQLEN, :VARLEN_KV_SEQLEN]
+    golden_out = torch.empty((t_q, VARLEN_NUM_HEADS, VARLEN_HEAD_SIZE), dtype=DATA_TYPE)
+    golden_lse = torch.empty((VARLEN_BATCH_SIZE, VARLEN_NUM_HEADS, VARLEN_Q_SEQLEN), dtype=torch.float32)
+    for i in range(VARLEN_BATCH_SIZE):
+        q_start = 0 if i == 0 else sum(q_sequences[:i])
+        kv_start = 0 if i == 0 else sum(kv_sequences[:i])
+        query_cpu = query.detach().cpu()[q_start:q_start + q_sequences[i]].unsqueeze(0)
+        key_cpu = key_cache.detach().cpu()[kv_start:kv_start + kv_sequences[i]].unsqueeze(0)
+        value_cpu = value_cache.detach().cpu()[kv_start:kv_start + kv_sequences[i]].unsqueeze(0)
+        output, lse = ref_flash_attention(
+            query_cpu, key_cpu, value_cpu,
+            VARLEN_SCALE, atten_mask, DATA_TYPE, softcap=0.0,
+        )
+        golden_out[q_start:q_start + q_sequences[i]] = output
+        golden_lse[i:i + 1] = lse.reshape(VARLEN_NUM_HEADS, VARLEN_Q_SEQLEN)
+
+    # warm-up
+    flash_attn_varlen_func(
+        query, key_cache, value_cache,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=VARLEN_Q_SEQLEN,
+        max_seqlen_k=VARLEN_KV_SEQLEN,
+        softmax_scale=VARLEN_SCALE,
+        causal=is_causal,
+        window_size=WINDOW_SIZE,
+        scheduler_metadata=scheduler_metadata,
+        return_lse=False,
+    )
+    torch.npu.synchronize()
+
+    # graph capture
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        output_npu = flash_attn_varlen_func(
+            query, key_cache, value_cache,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=VARLEN_Q_SEQLEN,
+            max_seqlen_k=VARLEN_KV_SEQLEN,
+            softmax_scale=VARLEN_SCALE,
+            causal=is_causal,
+            window_size=WINDOW_SIZE,
+            scheduler_metadata=scheduler_metadata,
+            return_lse=False,
+        )
+
+    graph.replay()
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(output_npu.cpu(), golden_out, rtol=RTOL, atol=ATOL)
+    del graph

--- a/tests/test_flash_attn_npu_v4_metadata.py
+++ b/tests/test_flash_attn_npu_v4_metadata.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, Minghua Shen.
+
+import pytest
+import torch
+import torch_npu
+if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count() > 0 else ""):
+    pytest.skip("flash_attn_func / flash_attn_varlen_func / get_scheduler_metadata not on Ascend950", allow_module_level=True)
+
+from flash_attn_npu_4 import (
+    flash_attn_varlen_func,
+    get_scheduler_metadata,
+)
+from tests.test_flash_attn_npu_v4 import ref_flash_attention
+from tests.npu_precision_utils import compare_rule
+
+
+RTOL = 2e-2
+ATOL = 2e-2
+WINDOW_SIZE = (-1, -1)
+
+WIDE_RANGE = (-5.0, 5.0)
+
+
+def _rand_npu(shape, data_type, value_range):
+    low, high = value_range
+    return (low + (high - low) * torch.rand(shape)).to(data_type).npu()
+
+
+def _prefix_sums(lengths):
+    offsets = [0]
+    for length in lengths:
+        offsets.append(offsets[-1] + length)
+    return offsets
+
+
+def _int32_npu(values):
+    return torch.tensor(values, dtype=torch.int32).npu()
+
+
+def _metadata(
+    *,
+    batch_size, q_seqlen, kv_seqlen, num_heads, kv_heads, head_size,
+    cache_seqlens, data_type, cu_seqlens_q=None, page_size=None,
+    is_causal=False, num_splits=0,
+):
+    return get_scheduler_metadata(
+        batch_size=batch_size, max_seqlen_q=q_seqlen, max_seqlen_k=kv_seqlen,
+        num_heads_q=num_heads, num_heads_kv=kv_heads, headdim=head_size,
+        cache_seqlens=cache_seqlens, qkv_dtype=data_type,
+        cu_seqlens_q=cu_seqlens_q, page_size=page_size,
+        causal=is_causal, window_size=WINDOW_SIZE, num_splits=num_splits,
+    )
+
+
+def _causal_mask(q_seqlen, kv_seqlen):
+    return torch.triu(
+        torch.ones(q_seqlen, kv_seqlen),
+        diagonal=kv_seqlen - q_seqlen + 1,
+    ).bool()
+
+
+# ---------------------------------------------------------------------------
+# Golden builders  (same pattern as test_flash_attn_npu_v4.py)
+# ---------------------------------------------------------------------------
+
+def _build_golden_tnd(
+    query, kv_for_batch, *, q_offsets, batch_size, num_heads, head_size,
+    scale, data_type, is_causal, softcap=0.0,
+):
+    query_cpu = query.detach().cpu()
+    t_q = q_offsets[-1]
+    golden_out = torch.empty((t_q, num_heads, head_size), dtype=data_type)
+    golden_lse = torch.empty((num_heads, t_q), dtype=torch.float32)
+    for bi in range(batch_size):
+        s, e = q_offsets[bi], q_offsets[bi + 1]
+        k_cpu, v_cpu = kv_for_batch(bi)
+        mask = _causal_mask(e - s, k_cpu.shape[0]) if is_causal else None
+        out, lse = ref_flash_attention(
+            query_cpu[s:e].unsqueeze(0), k_cpu.unsqueeze(0), v_cpu.unsqueeze(0),
+            scale, mask, data_type, softcap=softcap,
+        )
+        golden_out[s:e] = out.reshape(e - s, num_heads, head_size)
+        golden_lse[:, s:e] = lse.reshape(num_heads, e - s)
+    return golden_out, golden_lse
+
+
+# ---------------------------------------------------------------------------
+# Test cases (same format as test_flash_attn_npu_v4.py)
+#   (data_type, B, H, Hkv, Q, KV, D, page_sz, causal, layout, cache_mode)
+# ---------------------------------------------------------------------------
+
+VARLEN_CASES = [
+    (torch.bfloat16, 1, 1, 1, 512,  1024, 128, 128, True,  "TND", 0),
+    (torch.bfloat16, 2, 4, 4, 1024, 1024, 128, 128, False, "TND", 0),
+    (torch.float16,   7, 5, 1, 512,  512,  128, 128, True,  "TND", 0),
+    (torch.bfloat16, 5, 4, 4, 512,  512,  128, 128, True,  "TND", 0),
+    (torch.float16,   7, 5, 1, 777,  888,  192, 128, False, "TND", 0),
+    (torch.bfloat16, 1, 1, 1, 7777, 8192, 64,  128, True,  "TND", 0),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, "
+    "head_size, block_size, is_causal, layout, cache_mode",
+    VARLEN_CASES,
+)
+def test_flash_attn_varlen_func_metadata_tnd(
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen,
+    head_size, block_size, is_causal, layout, cache_mode,
+):
+    """flash_attn_varlen_func + scheduler_metadata — golden vs CANN comparison."""
+    q_lengths = [q_seqlen] * batch_size
+    kv_lengths = [kv_seqlen] * batch_size
+    q_offsets = _prefix_sums(q_lengths)
+    kv_offsets = _prefix_sums(kv_lengths)
+
+    query = _rand_npu((q_offsets[-1], num_heads, head_size), data_type, WIDE_RANGE)
+    key = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    value = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    scale = 1.0 / (head_size ** 0.5)
+
+    cu_seqlens_q = _int32_npu(q_offsets)
+    cu_seqlens_k = _int32_npu(kv_offsets)
+    cache_seqlens = _int32_npu(kv_lengths)
+
+    meta = _metadata(
+        batch_size=batch_size, q_seqlen=q_seqlen, kv_seqlen=kv_seqlen,
+        num_heads=num_heads, kv_heads=kv_heads, head_size=head_size,
+        cache_seqlens=cache_seqlens, data_type=data_type,
+        cu_seqlens_q=cu_seqlens_q, is_causal=is_causal,
+    )
+
+    out_npu = flash_attn_varlen_func(
+        query, key, value, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=q_seqlen, max_seqlen_k=kv_seqlen, softmax_scale=scale,
+        causal=is_causal, window_size=WINDOW_SIZE, num_splits=1,
+        scheduler_metadata=meta,
+    )
+
+    key_cpu = key.detach().cpu()
+    value_cpu = value.detach().cpu()
+    golden_out, _ = _build_golden_tnd(
+        query,
+        lambda bi: (key_cpu[kv_offsets[bi]:kv_offsets[bi + 1]],
+                    value_cpu[kv_offsets[bi]:kv_offsets[bi + 1]]),
+        q_offsets=q_offsets, batch_size=batch_size, num_heads=num_heads,
+        head_size=head_size, scale=scale, data_type=data_type, is_causal=is_causal,
+    )
+
+    torch.testing.assert_close(out_npu.cpu(), golden_out, rtol=RTOL, atol=ATOL)
+    if data_type == torch.bfloat16:
+        _, ok = compare_rule(golden_out.cpu().float(), out_npu.cpu().float(),
+                             ratios=(0.05, 0.05, 0.05, 0.05))
+    else:
+        _, ok = compare_rule(golden_out.cpu().float(), out_npu.cpu().float())
+    assert ok, "Golden vs CANN (metadata varlen) check FAILED"
+
+
+def test_flash_attn_varlen_func_metadata_disabled():
+    """flash_attn_varlen_func with disable_scheduler_metadata=True should produce same result."""
+    data_type = torch.bfloat16
+    batch_size = 2
+    num_heads = 4
+    kv_heads = 4
+    q_seqlen = 1024
+    kv_seqlen = 1024
+    head_size = 128
+    is_causal = True
+
+    q_lengths = [q_seqlen] * batch_size
+    kv_lengths = [kv_seqlen] * batch_size
+    q_offsets = _prefix_sums(q_lengths)
+    kv_offsets = _prefix_sums(kv_lengths)
+
+    query = _rand_npu((q_offsets[-1], num_heads, head_size), data_type, WIDE_RANGE)
+    key = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    value = _rand_npu((kv_offsets[-1], kv_heads, head_size), data_type, WIDE_RANGE)
+    scale = 1.0 / (head_size ** 0.5)
+
+    cu_seqlens_q = _int32_npu(q_offsets)
+    cu_seqlens_k = _int32_npu(kv_offsets)
+    cache_seqlens = _int32_npu(kv_lengths)
+
+    meta = _metadata(
+        batch_size=batch_size, q_seqlen=q_seqlen, kv_seqlen=kv_seqlen,
+        num_heads=num_heads, kv_heads=kv_heads, head_size=head_size,
+        cache_seqlens=cache_seqlens, data_type=data_type,
+        cu_seqlens_q=cu_seqlens_q, is_causal=is_causal,
+    )
+
+    # With metadata (normal)
+    out_with_meta = flash_attn_varlen_func(
+        query, key, value, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=q_seqlen, max_seqlen_k=kv_seqlen, softmax_scale=scale,
+        causal=is_causal, window_size=WINDOW_SIZE, num_splits=1,
+        scheduler_metadata=meta,
+    )
+
+    # With disable_scheduler_metadata=True (should ignore meta)
+    out_disabled = flash_attn_varlen_func(
+        query, key, value, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=q_seqlen, max_seqlen_k=kv_seqlen, softmax_scale=scale,
+        causal=is_causal, window_size=WINDOW_SIZE, num_splits=1,
+        scheduler_metadata=meta,
+        disable_scheduler_metadata=True,
+    )
+
+    torch.testing.assert_close(out_with_meta.cpu(), out_disabled.cpu(), rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
️Related Issue
https://github.com/MinghuasLab/flash-attention-npu/issues/37

Description
Add optional device-side scheduler_metadata support for FlashAttention NPU V4 APIs, so scheduling metadata can be precomputed and passed directly to the kernel path.

Changes
 Changed ...
 Added ...
 Removed ...
Additional Information
None