### PR TITLE
ci: isolate parallel test logs

### DIFF
--- a/.github/workflows/npu_ci.yml
+++ b/.github/workflows/npu_ci.yml
@@ -241,6 +241,7 @@ jobs:
       CI_NPU_MAX_TASKS: ${{ matrix.max_tasks }}
       TARGET_SHA: ${{ needs.prepare.outputs.sha }}
       CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
+      CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
     outputs:
       run_outcome: ${{ steps.run.outcome }}
     steps:
@@ -362,7 +363,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.arch_label }}
-          path: /tmp/ci_test_logs/
+          path: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}/
           retention-days: 7
 
       - name: Clean up this job's CI containers

--- a/.github/workflows/npu_ci_full.yml
+++ b/.github/workflows/npu_ci_full.yml
@@ -76,6 +76,7 @@ jobs:
       CI_MODE: full
       CI_REF: ${{ github.event.inputs.ref }}
       CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
+      CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
     steps:
       - name: Check arch match
         id: arch
@@ -143,7 +144,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.arch_label }}
-          path: /tmp/ci_test_logs/
+          path: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}/
           retention-days: 7
 
       - name: Clean up this job's CI containers

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -33,9 +33,10 @@ CI_DOCKER_PRIVILEGED="${CI_DOCKER_PRIVILEGED:-true}"
 CI_DOCKER_IMAGE="${CI_DOCKER_IMAGE:-fa-npu-ci:910b-cann9.1-torch2.9}"
 CI_SKIP_BUILD="${CI_SKIP_BUILD:-false}"
 CI_CONTAINER_SCOPE="${CI_CONTAINER_SCOPE:-local-$(id -u)-$$}"
-# 宿主机日志目录: 挂载进容器, 容器内写的日志直接落到宿主机, 避免 --rm 删除容器后日志丢失。
-# 同时让 workflow 的 upload-artifact (path: /tmp/ci_test_logs) 能读到日志。
-CI_TEST_LOG_DIR_HOST="${CI_TEST_LOG_DIR_HOST:-/tmp/ci_test_logs}"
+# 宿主机日志目录: 按当前 CI scope 隔离, 避免同一 runner 上的并行 job 互相覆盖。
+# 容器内仍固定使用 /tmp/ci_test_logs, workflow 上传对应的宿主机子目录。
+CI_LOG_SCOPE="${CI_CONTAINER_SCOPE//[^A-Za-z0-9_.-]/_}"
+CI_TEST_LOG_DIR_HOST="${CI_TEST_LOG_DIR_HOST:-/tmp/ci_test_logs/$CI_LOG_SCOPE}"
 
 log() { printf '[CI] %s\n' "$*"; }
 die() { printf '[CI][ERROR] %s\n' "$*" >&2; exit 1; }


### PR DESCRIPTION
## Related Issue

#172 
<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->



## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

- Give each CI job an isolated host-side test log directory.
- Derive the directory name from the CI run ID, run attempt, job name, and architecture.
- Update artifact upload paths to match the job-specific log directories.
- Preserve the existing container-side path used by `ci/run_ci_test.sh`.

The previous implementation shared `/tmp/ci_test_logs` across concurrent jobs. Since each job wrote fixed filenames such as `all_tests.log`, `direct.log`, and `failed_cases.txt`, parallel jobs could overwrite or mix each other's logs.


## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->

- `bash -n ci/run_ci_container.sh ci/run_ci_test.sh`
- Parsed `.github/workflows/npu_ci.yml` successfully.
- Parsed `.github/workflows/npu_ci_full.yml` successfully.
- `git diff --check`
- Verified that the host-side mount path and artifact upload path use the same job-specific directory.
- Verified that the generated scope-based path contains only safe filename characters.

Full NPU CI validation requires access to the self-hosted NPU runners.

## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->

The container-side log directory remains `/tmp/ci_test_logs`, so no changes are required in `ci/run_ci_test.sh`. Only the host-side directory and workflow artifact path are isolated per CI job.