### PR TITLE
test: persist golden references for CI

### DIFF
--- a/.github/workflows/npu_ci.yml
+++ b/.github/workflows/npu_ci.yml
@@ -242,6 +242,9 @@ jobs:
       TARGET_SHA: ${{ needs.prepare.outputs.sha }}
       CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
       CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
+      GOLDEN_CACHE_HOST_DIR: /home/FA_NPU_CI_DATA
+      GOLDEN_CACHE_DIR: /var/cache/flash-attention-npu/golden_cache
+      GOLDEN_CACHE_MODE: cache
     outputs:
       run_outcome: ${{ steps.run.outcome }}
     steps:

--- a/.github/workflows/npu_ci_full.yml
+++ b/.github/workflows/npu_ci_full.yml
@@ -77,6 +77,9 @@ jobs:
       CI_REF: ${{ github.event.inputs.ref }}
       CI_CONTAINER_SCOPE: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
       CI_TEST_LOG_DIR_HOST: /tmp/ci_test_logs/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.arch_label }}
+      GOLDEN_CACHE_HOST_DIR: /home/FA_NPU_CI_DATA
+      GOLDEN_CACHE_DIR: /var/cache/flash-attention-npu/golden_cache
+      GOLDEN_CACHE_MODE: cache
     steps:
       - name: Check arch match
         id: arch

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -20,6 +20,9 @@
 #   CI_NPU_WAIT_MAX_SEC      (默认 600)    所有卡忙时最长等待秒数
 #   CI_NPU_WAIT_INTERVAL_SEC (默认 30)     所有卡忙时重探间隔秒数
 #   ASCEND_RT_VISIBLE_DEVICES               手动指定宿主机物理卡时跳过自动选卡
+#   GOLDEN_CACHE_HOST_DIR (CI 固定为 /home/FA_NPU_CI_DATA)
+#   GOLDEN_CACHE_DIR      (默认 /var/cache/flash-attention-npu/golden_cache)
+#   GOLDEN_CACHE_MODE     (默认 cache) cache|off
 
 set -euo pipefail
 
@@ -33,10 +36,11 @@ CI_DOCKER_PRIVILEGED="${CI_DOCKER_PRIVILEGED:-true}"
 CI_DOCKER_IMAGE="${CI_DOCKER_IMAGE:-fa-npu-ci:910b-cann9.1-torch2.9}"
 CI_SKIP_BUILD="${CI_SKIP_BUILD:-false}"
 CI_CONTAINER_SCOPE="${CI_CONTAINER_SCOPE:-local-$(id -u)-$$}"
-# 宿主机日志目录: 按当前 CI scope 隔离, 避免同一 runner 上的并行 job 互相覆盖。
-# 容器内仍固定使用 /tmp/ci_test_logs, workflow 上传对应的宿主机子目录。
 CI_LOG_SCOPE="${CI_CONTAINER_SCOPE//[^A-Za-z0-9_.-]/_}"
 CI_TEST_LOG_DIR_HOST="${CI_TEST_LOG_DIR_HOST:-/tmp/ci_test_logs/$CI_LOG_SCOPE}"
+GOLDEN_CACHE_HOST_DIR="${GOLDEN_CACHE_HOST_DIR:-/home/FA_NPU_CI_DATA}"
+GOLDEN_CACHE_DIR="${GOLDEN_CACHE_DIR:-/var/cache/flash-attention-npu/golden_cache}"
+GOLDEN_CACHE_MODE="${GOLDEN_CACHE_MODE:-cache}"
 
 log() { printf '[CI] %s\n' "$*"; }
 die() { printf '[CI][ERROR] %s\n' "$*" >&2; exit 1; }
@@ -125,6 +129,17 @@ run_docker_test() {
   # 创建宿主机日志目录并开放权限 (容器内 root 写, 宿主机 runner 用户读)
   mkdir -p "$CI_TEST_LOG_DIR_HOST"
   chmod 777 "$CI_TEST_LOG_DIR_HOST" 2>/dev/null || true
+  local golden_mount_args=()
+  if [ "$GOLDEN_CACHE_MODE" != "off" ] && [ "$GOLDEN_CACHE_MODE" != "0" ]; then
+    # The test container runs as root, so a pre-provisioned root-owned directory
+    # is valid even when the runner user itself cannot write to it.
+    if mkdir -p "$GOLDEN_CACHE_HOST_DIR" 2>/dev/null && [ -d "$GOLDEN_CACHE_HOST_DIR" ]; then
+      golden_mount_args=(-v "$GOLDEN_CACHE_HOST_DIR:$GOLDEN_CACHE_DIR:rw")
+    else
+      log "warning: golden cache directory is unavailable ($GOLDEN_CACHE_HOST_DIR); disabling cache"
+      GOLDEN_CACHE_MODE=off
+    fi
+  fi
   docker run --rm \
     --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
     "${privileged_args[@]}" \
@@ -132,6 +147,7 @@ run_docker_test() {
     --ipc host \
     -v "$REPO_ROOT:/workspace/flash-attention-npu" \
     -v "$CI_TEST_LOG_DIR_HOST:/tmp/ci_test_logs" \
+    "${golden_mount_args[@]}" \
     "${mount_args[@]}" \
     -e ASCEND_RT_VISIBLE_DEVICES="$device_id" \
     -e CI_MODE="$CI_MODE" \
@@ -143,6 +159,11 @@ run_docker_test() {
     -e CI_QUICK_SAMPLE="${CI_QUICK_SAMPLE:-30}" \
     -e CI_TEST_LOG_DIR="/tmp/ci_test_logs" \
     -e CI_CONTAINER_DEVICE="$CI_CONTAINER_DEVICE" \
+    -e GOLDEN_CACHE_MODE="$GOLDEN_CACHE_MODE" \
+    -e GOLDEN_CACHE_DIR="$GOLDEN_CACHE_DIR" \
+    -e GOLDEN_CACHE_REFRESH="${GOLDEN_CACHE_REFRESH:-0}" \
+    -e GOLDEN_CACHE_MAX_DIRS="${GOLDEN_CACHE_MAX_DIRS:-5}" \
+    -e GOLDEN_CACHE_MAX_TEST_DIRS="${GOLDEN_CACHE_MAX_TEST_DIRS:-5}" \
     -e FLASH_ATTN_BUILD_VERSION="${FLASH_ATTN_BUILD_VERSION:-all}" \
     -e GIT_CONFIG_GLOBAL=/tmp/gitconfig \
     -w /workspace/flash-attention-npu \

--- a/tests/common/attention_ref.py
+++ b/tests/common/attention_ref.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2026, Minghua Shen.
+import os
+
 import torch
+
+from tests.common.golden_cache import get_or_compute_golden
 """
   Shared FlashAttention NPU reference / golden implementation.
 
@@ -183,7 +187,8 @@ def ref_flash_attention(
         out = pv_out(prob, value).permute(0, 2, 1, 3)
     return out.to(dtype_og), lse
 
-def ref_flash_attention_pair(
+
+def _ref_flash_attention_pair(
     query,
     key,
     value,
@@ -209,3 +214,170 @@ def ref_flash_attention_pair(
         drop_mask=drop_mask, dropout_p=dropout_p, **kwargs,
     )
     return out_ref, lse_ref, out_pt, lse_pt
+
+
+def _golden_metadata(query, key, value, scale, mask, data_type, softcap, extra=None):
+    metadata = {
+        "query_shape": list(query.shape),
+        "key_shape": list(key.shape),
+        "value_shape": list(value.shape),
+        "query_dtype": str(query.dtype),
+        "key_dtype": str(key.dtype),
+        "value_dtype": str(value.dtype),
+        "data_type": str(data_type),
+        "scale": scale,
+        "softcap": softcap,
+    }
+    if extra:
+        metadata.update(extra)
+    return metadata
+
+
+def cached_ref_flash_attention_pair(
+    query,
+    key,
+    value,
+    scale,
+    mask,
+    data_type,
+    softcap=0.0,
+    *,
+    nodeid=None,
+    rescale_threshold=None,
+    sink_matrix=None,
+    drop_mask=None,
+    dropout_p=0.0,
+    metadata=None,
+):
+    """Cached wrapper for the two forward reference implementations."""
+    case_metadata = _golden_metadata(
+        query, key, value, scale, mask, data_type, softcap, metadata
+    )
+    case_metadata["rescale_threshold"] = rescale_threshold
+    case_metadata["dropout_p"] = dropout_p
+    inputs = {
+        "query": query,
+        "key": key,
+        "value": value,
+        "mask": mask,
+        "sink": sink_matrix,
+        "drop_mask": drop_mask,
+    }
+
+    def compute():
+        values = _ref_flash_attention_pair(
+            query, key, value, scale, mask, data_type, softcap,
+            rescale_threshold=rescale_threshold, sink_matrix=sink_matrix,
+            drop_mask=drop_mask, dropout_p=dropout_p,
+        )
+        return dict(zip(("out_ref", "lse_ref", "out_pt", "lse_pt"), values))
+
+    values = get_or_compute_golden(
+        nodeid=nodeid or _current_nodeid(),
+        metadata=case_metadata,
+        inputs=inputs,
+        compute_fn=compute,
+        expected_keys=("out_ref", "lse_ref", "out_pt", "lse_pt"),
+        source_files=[__file__],
+        test_source_files=_golden_test_source_files(),
+    )
+    return tuple(values[name] for name in ("out_ref", "lse_ref", "out_pt", "lse_pt"))
+
+
+def cached_autograd_grads(nodeid, outputs, refs, dout, *, metadata=None, inputs=None):
+    """Cache an existing pair of reference autograd results.
+
+    ``outputs`` and ``refs`` are the exact tensors already built by the test,
+    so this helper also works for packed/varlen views whose gradient shape is
+    different from the padded reference input.
+    """
+    query, key, value = refs
+    case_metadata = {
+        "gradient": True,
+        "metadata": _json_metadata(metadata),
+        "output_shapes": [list(outputs[0].shape), list(outputs[1].shape)],
+    }
+    caller_inputs = inputs if inputs is not None else {
+        "query": query,
+        "key": key,
+        "value": value,
+        "dout": dout,
+    }
+    cache_inputs = {
+        "caller_inputs": caller_inputs,
+        "out_ref": outputs[0],
+        "out_pt": outputs[1],
+    }
+
+    def compute():
+        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
+            outputs[0], refs, dout.detach().cpu(), retain_graph=True
+        )
+        dq_pt, dk_pt, dv_pt = torch.autograd.grad(
+            outputs[1], refs, dout.detach().cpu()
+        )
+        return {
+            "dq_ref": dq_ref, "dk_ref": dk_ref, "dv_ref": dv_ref,
+            "dq_pt": dq_pt, "dk_pt": dk_pt, "dv_pt": dv_pt,
+        }
+
+    values = get_or_compute_golden(
+        nodeid=nodeid,
+        metadata=case_metadata,
+        inputs=cache_inputs,
+        compute_fn=compute,
+        expected_keys=("dq_ref", "dk_ref", "dv_ref", "dq_pt", "dk_pt", "dv_pt"),
+        source_files=[__file__],
+        test_source_files=_golden_test_source_files(),
+    )
+    return tuple(values[name] for name in ("dq_ref", "dk_ref", "dv_ref", "dq_pt", "dk_pt", "dv_pt"))
+
+
+def _json_metadata(value):
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    return {"value": value}
+
+
+def _golden_test_source_files():
+    test_file = os.environ.get("GOLDEN_CACHE_TEST_FILE")
+    return [test_file] if test_file else []
+
+
+def _current_nodeid():
+    return os.environ.get("GOLDEN_CACHE_NODEID", "standalone")
+
+
+def ref_flash_attention_pair(
+    query,
+    key,
+    value,
+    scale,
+    mask,
+    data_type,
+    softcap=0.0,
+    rescale_threshold=None,
+    sink_matrix=None,
+    drop_mask=None,
+    dropout_p=0.0,
+):
+    # Backward tests need the live CPU graph to remain available when their
+    # separate gradient artifact is missing or being refreshed.  Forward-only
+    # cases use the persistent cache below.
+    if any(
+        isinstance(tensor, torch.Tensor) and tensor.requires_grad
+        for tensor in (query, key, value)
+    ):
+        return _ref_flash_attention_pair(
+            query, key, value, scale, mask, data_type, softcap,
+            rescale_threshold=rescale_threshold, sink_matrix=sink_matrix,
+            drop_mask=drop_mask, dropout_p=dropout_p,
+        )
+    return cached_ref_flash_attention_pair(
+        query, key, value, scale, mask, data_type, softcap,
+        nodeid=_current_nodeid(),
+        rescale_threshold=rescale_threshold, sink_matrix=sink_matrix,
+        drop_mask=drop_mask, dropout_p=dropout_p,
+    )

--- a/tests/common/golden_cache.py
+++ b/tests/common/golden_cache.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026, Minghua Shen.
+"""Persistent, best-effort cache for CPU reference (golden) tensors.
+
+The cache is deliberately independent from pytest and NPU state.  Callers pass
+case metadata, the CPU inputs used by the reference, and a function that
+returns a mapping of tensors.  A cache failure only causes a recomputation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import torch
+
+
+_FORMAT_VERSION = 1
+_DEFAULT_CACHE_DIR = "/var/cache/flash-attention-npu/golden_cache"
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    return os.environ.get(name, "1" if default else "0").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, torch.dtype):
+        return str(value)
+    if isinstance(value, Path):
+        return str(value)
+    return repr(value)
+
+
+def _tensor_digest(tensor: torch.Tensor) -> dict[str, Any]:
+    cpu = tensor.detach().to(device="cpu").contiguous()
+    data = cpu.view(torch.uint8).numpy().tobytes()
+    return {
+        "dtype": str(cpu.dtype),
+        "shape": list(cpu.shape),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def input_digest(inputs: Any) -> Any:
+    """Return a deterministic, content-based digest description for inputs."""
+    if isinstance(inputs, torch.Tensor):
+        return _tensor_digest(inputs)
+    if isinstance(inputs, Mapping):
+        return {str(key): input_digest(inputs[key]) for key in sorted(inputs, key=str)}
+    if isinstance(inputs, (list, tuple)):
+        return [input_digest(item) for item in inputs]
+    return _json_value(inputs)
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        _json_value(value), sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _source_digest(paths: list[str] | tuple[str, ...] | None) -> str:
+    hasher = hashlib.sha256()
+    for path in sorted(paths or ()):
+        hasher.update(path.encode())
+        try:
+            hasher.update(Path(path).read_bytes())
+        except OSError:
+            hasher.update(b"<missing>")
+    return hasher.hexdigest()
+
+
+def _cache_root() -> Path:
+    return Path(os.environ.get("GOLDEN_CACHE_DIR", _DEFAULT_CACHE_DIR))
+
+
+def _cache_enabled() -> bool:
+    return os.environ.get("GOLDEN_CACHE_MODE", "off").strip().lower() not in {
+        "off", "0", "false", "disabled"
+    }
+
+
+def _safe_name(value: str) -> str:
+    return "".join(char if char.isalnum() or char in "._-" else "_" for char in value)
+
+
+def _limits() -> tuple[int, int]:
+    def get(name: str, default: int) -> int:
+        try:
+            return max(1, int(os.environ.get(name, default)))
+        except ValueError:
+            return default
+
+    max_common = get("GOLDEN_CACHE_MAX_DIRS", 5)
+    return max_common, get("GOLDEN_CACHE_MAX_TEST_DIRS", max_common)
+
+
+@contextlib.contextmanager
+def _exclusive_lock(root: Path):
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / "golden_cache.lock"
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load_artifact(path: Path, expected: dict[str, Any]) -> dict[str, torch.Tensor]:
+    with tempfile.TemporaryDirectory(prefix="golden-read-", dir=path.parent) as temp:
+        with tarfile.open(path, "r:gz") as archive:
+            members = archive.getmembers()
+            for member in members:
+                if not member.isfile() or Path(member.name).name != member.name:
+                    raise ValueError("cache archive contains an unsupported member")
+                target = Path(temp, member.name).resolve()
+                if not str(target).startswith(str(Path(temp).resolve()) + os.sep):
+                    raise ValueError("cache archive contains an unsafe path")
+            archive.extractall(temp)
+        metadata = json.loads(Path(temp, "metadata.json").read_text())
+        if metadata != expected:
+            raise ValueError("cache metadata does not match current case")
+        result: dict[str, torch.Tensor] = {}
+        for tensor_path in sorted(Path(temp).glob("*.pt")):
+            with tensor_path.open("rb") as stream:
+                try:
+                    result[tensor_path.stem] = torch.load(
+                        stream, map_location="cpu", weights_only=True
+                    )
+                except TypeError:  # torch versions before weights_only
+                    stream.seek(0)
+                    result[tensor_path.stem] = torch.load(stream, map_location="cpu")
+        if not result:
+            raise ValueError("cache artifact contains no tensors")
+        expected_names = set(expected["value_names"])
+        if set(result) != expected_names:
+            raise ValueError(
+                f"cache artifact tensors {sorted(result)} do not match "
+                f"expected {sorted(expected_names)}"
+            )
+        return result
+
+
+def _write_artifact(
+    path: Path,
+    metadata: dict[str, Any],
+    values: Mapping[str, torch.Tensor],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix=".case-", suffix=".tar.gz", dir=path.parent, delete=False
+    ) as tmp:
+        temp_path = Path(tmp.name)
+    try:
+        with tempfile.TemporaryDirectory(prefix="golden-write-", dir=path.parent) as temp:
+            Path(temp, "metadata.json").write_text(
+                json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+            )
+            for name, value in values.items():
+                if not isinstance(value, torch.Tensor):
+                    raise TypeError(f"golden value {name!r} is not a tensor")
+                with Path(temp, f"{_safe_name(name)}.pt").open("wb") as stream:
+                    torch.save(value.detach().to(device="cpu"), stream)
+            with tarfile.open(temp_path, "w:gz") as archive:
+                for child in sorted(Path(temp).iterdir()):
+                    archive.add(child, arcname=child.name)
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _evict(root: Path) -> None:
+    max_common, max_test = _limits()
+    common_dirs = [path for path in root.glob("common_*") if path.is_dir()]
+    common_dirs.sort(
+        key=lambda path: max(
+            (item.stat().st_mtime for item in path.rglob("*.tar.gz")),
+            default=path.stat().st_mtime,
+        )
+    )
+    for path in common_dirs[:-max_common]:
+        shutil.rmtree(path, ignore_errors=True)
+    for common in common_dirs[-max_common:]:
+        test_dirs = [path for path in common.glob("test_*") if path.is_dir()]
+        test_dirs.sort(
+            key=lambda path: max(
+                (item.stat().st_mtime for item in path.glob("case_*.tar.gz")),
+                default=path.stat().st_mtime,
+            )
+        )
+        for path in test_dirs[:-max_test]:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def get_or_compute_golden(
+    *,
+    nodeid: str,
+    metadata: Mapping[str, Any],
+    inputs: Any,
+    compute_fn: Callable[[], Mapping[str, torch.Tensor]],
+    expected_keys: tuple[str, ...],
+    source_files: list[str] | tuple[str, ...] | None = None,
+    test_source_files: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Load a case artifact or compute and atomically persist it.
+
+    ``compute_fn`` is called only on a miss, a damaged artifact, or when
+    ``GOLDEN_CACHE_REFRESH=1`` is set.  Returned tensors are detached CPU
+    tensors on a cache hit and retain the caller's tensors on a miss.
+    """
+    if not _cache_enabled():
+        return dict(compute_fn())
+
+    value_names = sorted(set(expected_keys))
+    if len(value_names) != len(expected_keys):
+        raise ValueError("expected_keys must contain unique names")
+    case_metadata = {
+        "format_version": _FORMAT_VERSION,
+        "nodeid": nodeid,
+        "metadata": _json_value(dict(metadata)),
+        "inputs": input_digest(inputs),
+        "source_digest": _source_digest(source_files),
+        "test_source_digest": _source_digest(test_source_files),
+        "runtime": {"torch": torch.__version__},
+        "value_names": value_names,
+    }
+    common_hash = _sha256_json(
+        {"source": case_metadata["source_digest"], "runtime": case_metadata["runtime"]}
+    )[:16]
+    seed = _safe_name(
+        str(dict(metadata).get("seed", os.environ.get("CI_TORCH_SEED", "per-case")))
+    )
+    test_hash = _sha256_json(
+        {
+            "test_file": nodeid.split("::", 1)[0],
+            "source": case_metadata["test_source_digest"],
+        }
+    )[:16]
+    case_hash = _sha256_json(case_metadata)[:32]
+    root = _cache_root()
+    artifact = (
+        root
+        / f"common_{common_hash}_seed_{seed}"
+        / f"test_{test_hash}"
+        / f"case_{case_hash}.tar.gz"
+    )
+
+    refresh = _env_bool("GOLDEN_CACHE_REFRESH")
+    if not refresh and artifact.is_file():
+        try:
+            result = _load_artifact(artifact, case_metadata)
+            print(f"[golden-cache] hit {nodeid}")
+            return result
+        except Exception as exc:  # cache is an optimization, never a test failure
+            warnings.warn(
+                f"golden cache read failed for {nodeid}: {exc}; recomputing",
+                RuntimeWarning,
+            )
+
+    values = dict(compute_fn())
+    if set(values) != set(value_names):
+        raise ValueError(
+            f"computed golden tensors {sorted(values)} do not match "
+            f"expected {value_names}"
+        )
+    try:
+        with _exclusive_lock(root):
+            _write_artifact(artifact, case_metadata, values)
+            _evict(root)
+        print(f"[golden-cache] {'refresh' if refresh else 'miss'} {nodeid}")
+    except Exception as exc:
+        warnings.warn(
+            f"golden cache write failed for {nodeid}: {exc}; continuing",
+            RuntimeWarning,
+        )
+    return values
+
+
+__all__ = ["get_or_compute_golden", "input_digest"]

--- a/tests/common/test_golden_cache.py
+++ b/tests/common/test_golden_cache.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, Minghua Shen.
+
+import torch
+
+from tests.common.attention_ref import cached_ref_flash_attention_pair
+from tests.common.golden_cache import get_or_compute_golden
+
+
+def test_golden_cache_is_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("GOLDEN_CACHE_MODE", raising=False)
+    calls = {"count": 0}
+
+    def compute():
+        calls["count"] += 1
+        return {"out": torch.ones(1)}
+
+    kwargs = {
+        "nodeid": "tests/example.py::test_disabled",
+        "metadata": {},
+        "inputs": {"q": torch.ones(1)},
+        "compute_fn": compute,
+        "expected_keys": ("out",),
+    }
+    get_or_compute_golden(**kwargs)
+    get_or_compute_golden(**kwargs)
+
+    assert calls["count"] == 2
+    assert not list(tmp_path.iterdir())
+
+
+def test_golden_cache_miss_hit_and_refresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDEN_CACHE_MODE", "cache")
+    calls = {"count": 0}
+
+    def compute():
+        calls["count"] += 1
+        return {"out": torch.tensor([calls["count"]], dtype=torch.float32)}
+
+    kwargs = dict(
+        nodeid="tests/example.py::test_case[x]",
+        metadata={"seed": 7, "shape": [1]},
+        inputs={"q": torch.ones(1)},
+        compute_fn=compute,
+        expected_keys=("out",),
+    )
+    assert get_or_compute_golden(**kwargs)["out"].item() == 1
+    assert get_or_compute_golden(**kwargs)["out"].item() == 1
+    assert calls["count"] == 1
+
+    monkeypatch.setenv("GOLDEN_CACHE_REFRESH", "1")
+    assert get_or_compute_golden(**kwargs)["out"].item() == 2
+    assert calls["count"] == 2
+
+
+def test_golden_cache_input_change_and_corruption_recompute(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDEN_CACHE_MODE", "cache")
+    calls = {"count": 0}
+
+    def compute():
+        calls["count"] += 1
+        return {"out": torch.tensor([3])}
+
+    base = dict(
+        nodeid="case",
+        metadata={"seed": 0},
+        compute_fn=compute,
+        expected_keys=("out",),
+    )
+    get_or_compute_golden(inputs={"q": torch.zeros(1)}, **base)
+    artifact = next(tmp_path.rglob("case_*.tar.gz"))
+    artifact.write_bytes(b"broken")
+    get_or_compute_golden(inputs={"q": torch.zeros(1)}, **base)
+    assert calls["count"] == 2
+    get_or_compute_golden(inputs={"q": torch.ones(1)}, **base)
+    assert calls["count"] == 3
+
+
+def test_golden_cache_groups_cases_by_test_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDEN_CACHE_MODE", "cache")
+
+    def compute():
+        return {"out": torch.ones(1)}
+
+    for case in ("case_a", "case_b"):
+        get_or_compute_golden(
+            nodeid=f"tests/example.py::test_attention[{case}]",
+            metadata={"case": case},
+            inputs={"q": torch.tensor([case == "case_b"])},
+            compute_fn=compute,
+            expected_keys=("out",),
+        )
+
+    test_dirs = list(tmp_path.glob("common_*/test_*"))
+    assert len(test_dirs) == 1
+    assert len(list(test_dirs[0].glob("case_*.tar.gz"))) == 2
+
+
+def test_cached_reference_supports_dropout(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDEN_CACHE_MODE", "cache")
+    query = torch.ones((1, 2, 1, 2), dtype=torch.float32)
+    key = torch.ones_like(query)
+    value = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2)
+    drop_mask = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+    kwargs = {
+        "query": query,
+        "key": key,
+        "value": value,
+        "scale": 1.0,
+        "mask": None,
+        "data_type": torch.float32,
+        "drop_mask": drop_mask,
+        "dropout_p": 0.5,
+        "nodeid": "tests/example.py::test_dropout",
+    }
+
+    first = cached_ref_flash_attention_pair(**kwargs)
+    second = cached_ref_flash_attention_pair(**kwargs)
+    for first_tensor, second_tensor in zip(first, second):
+        torch.testing.assert_close(first_tensor, second_tensor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,10 @@ def _seed_per_case(request):
     seed = int(env_seed) if env_seed else zlib.crc32(
         request.node.nodeid.encode("utf-8"))
     torch.manual_seed(seed)
-    if hasattr(torch.npu, "manual_seed"):
+    if hasattr(torch, "npu") and hasattr(torch.npu, "manual_seed"):
         torch.npu.manual_seed(seed)
+    os.environ["GOLDEN_CACHE_NODEID"] = request.node.nodeid
+    os.environ["GOLDEN_CACHE_TEST_FILE"] = str(request.path)
     yield
+    os.environ.pop("GOLDEN_CACHE_NODEID", None)
+    os.environ.pop("GOLDEN_CACHE_TEST_FILE", None)

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026, Minghua Shen.
 
+import os
 import torch
 import torch_npu
 import pytest
@@ -8,7 +9,7 @@ if "Ascend950" in (torch_npu.npu.get_device_name() if torch_npu.npu.device_count
     pytest.skip("flash_attn_npu (v2) not supported on Ascend950", allow_module_level=True)
 
 from flash_attn_npu import flash_attn_with_kvcache, flash_attn_func, flash_attn_varlen_func
-from tests.common.attention_ref import ref_flash_attention_pair
+from tests.common.attention_ref import cached_autograd_grads, ref_flash_attention_pair
 from tests.common.compare import assert_fa_close
 from tests.common.test_utils import (
     gather_paged_kv,
@@ -467,16 +468,19 @@ def test_fa_func_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_se
             softmax_lse, golden_lseL_ref, golden_lseL_pt, softcap=softcap, name="softmax_lse"
         )
     dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_out, (query, key_cache, value_cache), dout)
-    dq_ref, dk_ref, dv_ref = torch.autograd.grad(
-        golden_out_ref,
+    dq_ref, dk_ref, dv_ref, dq_pt, dk_pt, dv_pt = cached_autograd_grads(
+        os.environ.get("GOLDEN_CACHE_NODEID", "v2"),
+        (golden_out_ref, golden_out_pt),
         (query_ref, key_ref, value_ref),
-        dout.detach().cpu(),
-        retain_graph=True,
-    )
-    dq_pt, dk_pt, dv_pt = torch.autograd.grad(
-        golden_out_pt,
-        (query_ref, key_ref, value_ref),
-        dout.detach().cpu(),
+        dout,
+        metadata={"version": 2, "kind": "bsnd", "dropout_p": dropout_p},
+        inputs={
+            "query": query_ref,
+            "key": key_ref,
+            "value": value_ref,
+            "dout": dout,
+            "drop_mask": drop_mask,
+        },
     )
     assert_fa_close(dq_ag, dq_ref, dq_pt, softcap=softcap, name="dQ")
     assert_fa_close(dk_ag, dk_ref, dk_pt, softcap=softcap, name="dK")
@@ -675,16 +679,19 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
     if cache_mode == 0:
         dout = make_random_tensor(output_npu.shape, output_npu.dtype, low=-0.5, high=0.5, device="npu")
         dq_ag, dk_ag, dv_ag = torch.autograd.grad(output_npu, (query, key, value), dout)
-        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
-            golden_out_ref,
+        dq_ref, dk_ref, dv_ref, dq_pt, dk_pt, dv_pt = cached_autograd_grads(
+            os.environ.get("GOLDEN_CACHE_NODEID", "v2-varlen"),
+            (golden_out_ref, golden_out_pt),
             (query_ref, key_ref, value_ref),
-            dout.detach().cpu(),
-            retain_graph=True,
-        )
-        dq_pt, dk_pt, dv_pt = torch.autograd.grad(
-            golden_out_pt,
-            (query_ref, key_ref, value_ref),
-            dout.detach().cpu(),
+            dout,
+            metadata={"version": 2, "kind": "varlen", "dropout_p": dropout_p},
+            inputs={
+                "query": query_ref,
+                "key": key_ref,
+                "value": value_ref,
+                "dout": dout,
+                "drop_mask": drop_mask,
+            },
         )
         assert_fa_close(dq_ag, dq_ref, dq_pt, softcap=softcap, name="dQ")
         assert_fa_close(dk_ag, dk_ref, dk_pt, softcap=softcap, name="dK")

--- a/tests/test_flash_attn_npu_v3.py
+++ b/tests/test_flash_attn_npu_v3.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2026, Minghua Shen.
 
+import os
 import torch
 import torch_npu
 import pytest
-from tests.common.attention_ref import ref_flash_attention_pair
+from tests.common.attention_ref import cached_autograd_grads, ref_flash_attention_pair
 from tests.common.compare import assert_fa_close
 from tests.common.test_utils import (
     gather_paged_kv,
@@ -593,16 +594,12 @@ def test_fa_func_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_se
     if "Ascend910" in name:
         dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_out, (query, key_cache, value_cache), dout)
         dout_ref = dout.detach().cpu()
-        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
-            golden_out_ref,
+        dq_ref, dk_ref, dv_ref, dq_pt, dk_pt, dv_pt = cached_autograd_grads(
+            os.environ.get("GOLDEN_CACHE_NODEID", "v3"),
+            (golden_out_ref, golden_out_pt),
             (query_ref, key_ref, value_ref),
             dout_ref,
-            retain_graph=True,
-        )
-        dq_pt, dk_pt, dv_pt = torch.autograd.grad(
-            golden_out_pt,
-            (query_ref, key_ref, value_ref),
-            dout_ref,
+            metadata={"version": 3, "kind": "bsnd"},
         )
         assert_fa_close(dq_ag, dq_ref, dq_pt, softcap=softcap, name="dQ")
         assert_fa_close(dk_ag, dk_ref, dk_pt, softcap=softcap, name="dK")
@@ -759,16 +756,12 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         assert_fa_close(softmax_lse, golden_lseL_ref, golden_lseL_pt, softcap=softcap, name="softmax_lse")
         dout = make_random_tensor(output_npu.shape, output_npu.dtype, low=-0.5, high=0.5, device="npu")
         dq_ag, dk_ag, dv_ag = torch.autograd.grad(output_npu, (query, key, value), dout)
-        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
-            golden_out_ref,
+        dq_ref, dk_ref, dv_ref, dq_pt, dk_pt, dv_pt = cached_autograd_grads(
+            os.environ.get("GOLDEN_CACHE_NODEID", "v3-varlen"),
+            (golden_out_ref, golden_out_pt),
             (query_ref, key_ref, value_ref),
             dout.detach().cpu(),
-            retain_graph=True,
-        )
-        dq_pt, dk_pt, dv_pt = torch.autograd.grad(
-            golden_out_pt,
-            (query_ref, key_ref, value_ref),
-            dout.detach().cpu(),
+            metadata={"version": 3, "kind": "varlen"},
         )
         assert_fa_close(dq_ag, dq_ref, dq_pt, softcap=softcap, name="dQ")
         assert_fa_close(dk_ag, dk_ref, dk_pt, softcap=softcap, name="dK")

--- a/tests/test_flash_attn_npu_v4.py
+++ b/tests/test_flash_attn_npu_v4.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2026, Minghua Shen.
 
+import os
 import torch
 import torch_npu
 import pytest
-from tests.common.attention_ref import ref_flash_attention, ref_flash_attention_pair
+from tests.common.attention_ref import cached_autograd_grads, ref_flash_attention, ref_flash_attention_pair
 from tests.common.compare import assert_fa_close
 from tests.common.test_utils import (
     gather_paged_kv_batch,
@@ -516,16 +517,12 @@ def test_fa_kvcache_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv
     if bwd_supported:
         dout = make_random_tensor(out_out.shape, out_out.dtype, low=-0.5, high=0.5, device="npu")
         dq_ag, dk_ag, dv_ag = torch.autograd.grad(out_out, (query, key_cache, value_cache), dout)
-        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
-            golden_out_gpu_ref,
+        dq_ref, dk_ref, dv_ref, dq_pt, dk_pt, dv_pt = cached_autograd_grads(
+            os.environ.get("GOLDEN_CACHE_NODEID", "v4"),
+            (golden_out_gpu_ref, golden_out_gpu_pt),
             (query_ref, key_ref, value_ref),
-            dout.detach().cpu(),
-            retain_graph=True,
-        )
-        dq_pt, dk_pt, dv_pt = torch.autograd.grad(
-            golden_out_gpu_pt,
-            (query_ref, key_ref, value_ref),
-            dout.detach().cpu(),
+            dout,
+            metadata={"version": 4},
         )
         assert_fa_close(dq_ag, dq_ref, dq_pt, name="dQ")
         assert_fa_close(dk_ag, dk_ref, dk_pt, name="dK")


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->
None.


## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

- Add persistent host-side Golden cache for CPU reference results.
- Store cached tensors under `/home/FA_NPU_CI_DATA` on CI runners.
- Reuse matching forward reference and backward gradient results across CI runs.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->


The changes still need to be tested on CI runner.

## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->

- The cache is a performance optimization only; NPU kernels and result comparisons still run for every test.
- The default CI cache location is `/home/FA_NPU_CI_DATA`, as required by the CI server.
- Cache failures do not fail the test directly; the test recomputes the Golden result instead.
- Set `GOLDEN_CACHE_MODE=off` to disable caching.
- Set `GOLDEN_CACHE_REFRESH=1` to regenerate existing cache entries.
- Cache eviction keeps at most five common implementation directories and five test directories per common directory.