### PR TITLE
fix: ascend950 scheduler metadata args race

### DIFF
--- a/csrc/ascend950/flash_attn_npu_3/flash_api.cpp
+++ b/csrc/ascend950/flash_attn_npu_3/flash_api.cpp
@@ -45,14 +45,10 @@ static at::Tensor GetSchedulerMetadataImpl(FAMetadataArgs args,
         ACL_CHECK(aclrtCreateEvent(&events.metadataDone));
     }
 
-    // AICPU 启动参数必须跨函数保持有效（启动后仍可能异步读取 args），
-    // 且 RunOpApiV2 可能在其它线程执行回调，所以赋值放在回调内进行。
-    static thread_local FAMetadataArgs metaArgs;
+    FAMetadataArgs metaArgs = args;
     auto metadata_task = [curHandle, aicpuHandle,
                           inputReady = events.inputReady,
-                          metadataDone = events.metadataDone,
-                          args]() -> int {
-        metaArgs = args;
+                          metadataDone = events.metadataDone, metaArgs]() mutable -> int {
         ACL_CHECK(aclrtRecordEvent(inputReady, curHandle));
         ACL_CHECK(aclrtStreamWaitEvent(aicpuHandle, inputReady));
         ComputeFAMetadata<<<1, nullptr, aicpuHandle>>>(&metaArgs, sizeof(metaArgs));

--- a/csrc/ascend950/flash_attn_npu_3/mha_fwd.cpp
+++ b/csrc/ascend950/flash_attn_npu_3/mha_fwd.cpp
@@ -458,7 +458,7 @@ mha_fwd(at::Tensor q,
         qDev, kDev, vDev, maskDevice, blockTableDev,
         oDev, lseDev, qSeqDev, kvSeqDev,
         wsDev, tilDev};
-    auto launch_fa_infer = [&]() -> int {
+    auto launch_fa_infer = [fwdArgs]() -> int {
         launch_fwd(fwdArgs);
         return 0;
     };


### PR DESCRIPTION
Replace the static thread_local FAMetadataArgs with a per-call copy captured by value in the async RunOpApiV2 task, matching the 910 backend. Consecutive forwards can otherwise overwrite the shared args before the AICPU metadata kernel reads them, producing corrupt tiling and aicore faults under back-to-back calls.

## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123
Fixes #142
  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->



## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->
fix: ascend950 scheduler metadata args race


## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->
<img width="1255" height="662" alt="image" src="https://github.com/user-attachments/assets/b4f2aa30-1b8c-4848-8743-158b6930e1a0" />



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->