### PR TITLE
ci: guard cleanup when scripts are unavailable

### DIFF
--- a/.github/workflows/npu_ci.yml
+++ b/.github/workflows/npu_ci.yml
@@ -367,9 +367,13 @@ jobs:
           retention-days: 7
 
       - name: Clean up this job's CI containers
-        if: always()
+        if: always() && steps.arch.outputs.match == 'true'
         run: |
-          bash ci/cleanup_ci_containers.sh
+          if [ -f ci/cleanup_ci_containers.sh ]; then
+            bash ci/cleanup_ci_containers.sh
+          else
+            echo "cleanup script not found; skipping cleanup"
+          fi
 
   finalize:
     name: 写最终状态

--- a/.github/workflows/npu_ci_full.yml
+++ b/.github/workflows/npu_ci_full.yml
@@ -140,7 +140,7 @@ jobs:
           bash ci/run_ci_container.sh
 
       - name: Upload test logs
-        if: always()
+        if: always() && steps.arch.outputs.match == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.arch_label }}
@@ -148,6 +148,10 @@ jobs:
           retention-days: 7
 
       - name: Clean up this job's CI containers
-        if: always()
+        if: always() && steps.arch.outputs.match == 'true'
         run: |
-          bash ci/cleanup_ci_containers.sh
+          if [ -f ci/cleanup_ci_containers.sh ]; then
+            bash ci/cleanup_ci_containers.sh
+          else
+            echo "cleanup script not found; skipping cleanup"
+          fi

--- a/.github/workflows/npu_ci_matrix.yml
+++ b/.github/workflows/npu_ci_matrix.yml
@@ -128,4 +128,8 @@ jobs:
       - name: Clean up this job's CI containers
         if: always()
         run: |
-          bash ci/cleanup_ci_containers.sh
+          if [ -f ci/cleanup_ci_containers.sh ]; then
+            bash ci/cleanup_ci_containers.sh
+          else
+            echo "cleanup script not found; skipping cleanup"
+          fi


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

None.

## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Fix CI cleanup failures when a matrix job is skipped due to an architecture mismatch or when the checked-out source tree does not contain the cleanup script.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->

The change only prevents cleanup and artifact-upload steps from running for skipped matrix jobs and avoids masking the original CI failure when the cleanup script is unavailable.
