### PR TITLE
Fix compilation error for __simd_vf__ on A5

### DIFF
--- a/csrc/ascend950/flash_attn_npu_3/online_softmax.hpp
+++ b/csrc/ascend950/flash_attn_npu_3/online_softmax.hpp
@@ -787,7 +787,7 @@ private:
     };
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMax(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMax(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -891,7 +891,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMax64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMax64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -983,7 +983,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMask(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMask(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1117,7 +1117,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMaskInvert(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMaskInvert(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1221,7 +1221,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMaskPreNext(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMaskPreNext(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskPreUb, __ubuf__ ElementMask *maskNextUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1334,7 +1334,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMask64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMask64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1436,7 +1436,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMaskInvert64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMaskInvert64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1515,7 +1515,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMaskPreNext64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxMaskPreNext64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskPreUb, __ubuf__ ElementMask *maskNextUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
     {
         using namespace AscendC::MicroAPI;
@@ -1599,7 +1599,7 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate, MAligendTileNum mTileNum>
-    __simd_vf__ inline void ComputeScaleAndMaxDn(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxDn(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, uint16_t mRound, uint16_t m, uint32_t tailN, uint32_t mFirstTile, ElementInput dScale, uint16_t S2BaseSize, 
         uint32_t blockStride, uint32_t repeatStride, __ubuf__ float *expMaxUb, __ubuf__ ElementS *lastExpSumUb)
     {
@@ -1861,7 +1861,7 @@ private:
     }
 
     template <typename ElementS>
-    __simd_vf__ inline void CastExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *maxUb,
+    __simd_vf__ static inline void CastExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *maxUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementS *nowMaxUb,
         uint16_t mLoops, uint32_t tailM)
     {
@@ -1908,7 +1908,7 @@ private:
     }
 
     template <typename ElementS>
-    __simd_vf__ inline void UpdateExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *expMaxUb,
+    __simd_vf__ static inline void UpdateExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *expMaxUb,
         __ubuf__ float *maxUb, __ubuf__ ElementS *expSumUb, __ubuf__ ElementS *nowMaxUb,
         uint16_t mLoops, uint32_t tailM)
     {

--- a/csrc/ascend950/flash_attn_npu_3/rescale_o.hpp
+++ b/csrc/ascend950/flash_attn_npu_3/rescale_o.hpp
@@ -291,7 +291,7 @@ public:
     // LSE has at most one float vector (64 elements) per sub-core.  Keep the
     // elementwise log(sum) + max in registers, then materialize it in LM for
     // Brcb and the existing block-aligned GM store path.
-    __simd_vf__ inline
+    __simd_vf__ static inline
     void ComputeLse(__ubuf__ float *glUb, __ubuf__ float *gmUb,
                            __ubuf__ float *lmUb, uint32_t rowCount)
     {
@@ -405,7 +405,7 @@ public:
     }
     
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void RescaleFunc(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *dmUb,
+    __simd_vf__ static inline void RescaleFunc(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *dmUb,
                                         uint32_t row, uint32_t col, uint32_t rowStride,
                                         uint32_t tailCols)
     {
@@ -489,7 +489,7 @@ public:
     }
 
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void RescaleFuncLastNotFirst(__ubuf__ T *goUb, __ubuf__ T *loUb,
+    __simd_vf__ static inline void RescaleFuncLastNotFirst(__ubuf__ T *goUb, __ubuf__ T *loUb,
                                         __ubuf__ T *dmUb, __ubuf__ T *glUb,
                                         uint32_t row, uint32_t col, uint32_t rowStride,
                                         uint32_t tailCols)
@@ -609,7 +609,7 @@ public:
     }
 
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void DivFuncLastAndFirst(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *glUb,
+    __simd_vf__ static inline void DivFuncLastAndFirst(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *glUb,
                                                 uint32_t row, uint32_t col, uint32_t rowStride,
                                                 uint32_t tailCols)
     {

--- a/csrc/ascend950/flash_attn_npu_4/online_softmax.hpp
+++ b/csrc/ascend950/flash_attn_npu_4/online_softmax.hpp
@@ -203,18 +203,18 @@ public:
         if (isFirstKvSTile) {
             if (n > 64) {
                 ComputeScaleAndMax<ElementInput, ElementOutput, false>(
-                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             } else {
                 ComputeScaleAndMax64<ElementInput, ElementOutput, false>(
-                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             }
         } else {
             if (n > 64) {
                 ComputeScaleAndMax<ElementInput, ElementOutput, true>(
-                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             } else {
                 ComputeScaleAndMax64<ElementInput, ElementOutput, true>(
-                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             }
         }
 
@@ -297,45 +297,45 @@ public:
             if (mAligned16TileNum == 0) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, false, MAligendTileNum::Zero>(
                     sAddr, lastMaxAddr, lastMaxStartAddr, pAddr, lastSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 1) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, false, MAligendTileNum::One>(
                     sAddr, lastMaxAddr, lastMaxStartAddr, pAddr, lastSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 2) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, false, MAligendTileNum::Two>(
                     sAddr, lastMaxAddr, lastMaxStartAddr, pAddr, lastSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 3) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, false, MAligendTileNum::Three>(
                     sAddr, lastMaxAddr, lastMaxStartAddr, pAddr, lastSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, false, MAligendTileNum::Four>(
                     sAddr, lastMaxAddr, lastMaxStartAddr, pAddr, lastSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             }
         } else {
             if (mAligned16TileNum == 0) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, true, MAligendTileNum::Zero>(
                     sAddr, nowMaxAddr, lastMaxAddr, pAddr, nowSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 1) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, true, MAligendTileNum::One>(
                     sAddr, nowMaxAddr, lastMaxAddr, pAddr, nowSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 2) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, true, MAligendTileNum::Two>(
                     sAddr, nowMaxAddr, lastMaxAddr, pAddr, nowSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else if (mAligned16TileNum == 3) {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, true, MAligendTileNum::Three>(
                     sAddr, nowMaxAddr, lastMaxAddr, pAddr, nowSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             } else {
                 ComputeScaleAndMaxDn<ElementInput, ElementOutput, true, MAligendTileNum::Four>(
                     sAddr, nowMaxAddr, lastMaxAddr, pAddr, nowSumAddr, mRound, m, tailN, mFirstTile, scaleValue, 64, blockStride, nRound,
-                    expMaxUbAddr, lastSumAddr);
+                    expMaxUbAddr, lastSumAddr, rescaleThreshold);
             }
         }
         
@@ -473,18 +473,18 @@ public:
         if (isFirstKvSTile) {
             if (n > 64) {
                 ComputeScaleAndMaxMask<ElementInput, ElementOutput, false>(
-                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             } else {
                 ComputeScaleAndMaxMask64<ElementInput, ElementOutput, false>(
-                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, lastMaxAddr, lastMaxStartAddr, lastMaxStartAddr, pAddr, lastSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             }
         } else {
             if (n > 64) {
                 ComputeScaleAndMaxMask<ElementInput, ElementOutput, true>(
-                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             } else {
                 ComputeScaleAndMaxMask64<ElementInput, ElementOutput, true>(
-                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound);
+                    sAddr, nowMaxAddr, nowMaxStartAddr, lastMaxStartAddr, pAddr, nowSumAddr, maskUbAddr, m, nLoops, tailN, nPadding, scaleValue, 128, blockStride, nRound, rescaleThreshold);
             }
         }
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(ubSBufId);
@@ -534,8 +534,8 @@ private:
     };
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMax(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
-        __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
+    __simd_vf__ static inline void ComputeScaleAndMax(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+        __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride, float rescaleThreshold)
     {
         using namespace AscendC::MicroAPI;
         RegTensor<float> minVreg;
@@ -639,8 +639,8 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMax64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
-        __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
+    __simd_vf__ static inline void ComputeScaleAndMax64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+        __ubuf__ ElementS *expSumUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride, float rescaleThreshold)
     {
         using namespace AscendC::MicroAPI;
         RegTensor<float> minVreg;
@@ -732,8 +732,8 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMask(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
-        __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
+    __simd_vf__ static inline void ComputeScaleAndMaxMask(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+        __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride, float rescaleThreshold)
     {
         using namespace AscendC::MicroAPI;
         RegTensor<float> minVreg;
@@ -867,8 +867,8 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate>
-    __simd_vf__ inline void ComputeScaleAndMaxMask64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
-        __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride)
+    __simd_vf__ static inline void ComputeScaleAndMaxMask64(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *newMaxUbStart, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+        __ubuf__ ElementS *expSumUb, __ubuf__ ElementMask *maskUb, uint16_t m, uint16_t nLoops, uint32_t tailN, uint32_t nPadding, ElementInput dScale, uint16_t S2BaseSize, uint32_t blockStride, uint32_t repeatStride, float rescaleThreshold)
     {
         using namespace AscendC::MicroAPI;
         RegTensor<float> minVreg;
@@ -970,9 +970,9 @@ private:
     }
 
     template <typename ElementS, typename ElementP, bool isUpdate, MAligendTileNum mTileNum>
-    __simd_vf__ inline void ComputeScaleAndMaxDn(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
+    __simd_vf__ static inline void ComputeScaleAndMaxDn(__ubuf__ ElementS *srcUb, __ubuf__ ElementS *newMaxUb, __ubuf__ ElementS *LastMaxUbStart, __ubuf__ ElementP *expUb,
         __ubuf__ ElementS *expSumUb, uint16_t mRound, uint16_t m, uint32_t tailN, uint32_t mFirstTile, ElementInput dScale, uint16_t S2BaseSize, 
-        uint32_t blockStride, uint32_t repeatStride, __ubuf__ float *expMaxUb, __ubuf__ ElementS *lastExpSumUb)
+        uint32_t blockStride, uint32_t repeatStride, __ubuf__ float *expMaxUb, __ubuf__ ElementS *lastExpSumUb, float rescaleThreshold)
     {
         using namespace AscendC::MicroAPI;
         RegTensor<float> src0Vreg;
@@ -1233,7 +1233,7 @@ private:
     }
 
     template <typename ElementS>
-    __simd_vf__ inline void CastExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *maxUb,
+    __simd_vf__ static inline void CastExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *maxUb,
         __ubuf__ ElementS *expSumUb, __ubuf__ ElementS *nowMaxUb,
         uint16_t mLoops, uint32_t tailM)
     {
@@ -1280,7 +1280,7 @@ private:
     }
 
     template <typename ElementS>
-    __simd_vf__ inline void UpdateExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *expMaxUb,
+    __simd_vf__ static inline void UpdateExpSumAndExpMax(__ubuf__ float *sumUb, __ubuf__ float *expMaxUb,
         __ubuf__ float *maxUb, __ubuf__ ElementS *expSumUb, __ubuf__ ElementS *nowMaxUb,
         uint16_t mLoops, uint32_t tailM)
     {

--- a/csrc/ascend950/flash_attn_npu_4/rescale_o.hpp
+++ b/csrc/ascend950/flash_attn_npu_4/rescale_o.hpp
@@ -229,7 +229,7 @@ public:
         }
     }
 
-    __simd_vf__ inline
+    __simd_vf__ static inline
     void ComputeLse(__ubuf__ float *glUb, __ubuf__ float *gmUb,
                            __ubuf__ float *lmUb, uint32_t rowCount)
     {
@@ -331,7 +331,7 @@ public:
     }
     
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void RescaleFuncGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *dmUb,
+    __simd_vf__ static inline void RescaleFuncGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb, __ubuf__ T *dmUb,
                                                uint32_t row, uint32_t col, uint32_t rowStride,
                                                uint32_t tailCols)
     {
@@ -414,7 +414,7 @@ public:
     }
 
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void RescaleFuncLastNotFirstGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb,
+    __simd_vf__ static inline void RescaleFuncLastNotFirstGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb,
                                                            __ubuf__ T *dmUb, __ubuf__ T *glUb,
                                                            uint32_t row, uint32_t col, uint32_t rowStride,
                                                            uint32_t tailCols)
@@ -510,7 +510,7 @@ public:
     }
 
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void DivFuncLastAndFirstGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb,
+    __simd_vf__ static inline void DivFuncLastAndFirstGeneric(__ubuf__ T *goUb, __ubuf__ T *loUb,
                                                        __ubuf__ T *glUb, uint32_t row, uint32_t col,
                                                        uint32_t rowStride,
                                                        uint32_t tailCols)
@@ -615,7 +615,7 @@ public:
 
     // Skip variant of RescaleFunc: dm == 1 for all rows, so go = go + lo.
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void AddFunc(__ubuf__ T *goUb, __ubuf__ T *loUb,
+    __simd_vf__ static inline void AddFunc(__ubuf__ T *goUb, __ubuf__ T *loUb,
                                     uint32_t row, uint32_t col, uint32_t rowStride,
                                     uint32_t tailCols)
     {
@@ -688,7 +688,7 @@ public:
 
     // Skip variant of RescaleFuncLastNotFirst: go = (go + lo) / gl.
     template <typename T, uint32_t ColBlocks, bool HeadDimAligned64 = true>
-    __simd_vf__ inline void AddDivFuncLastNotFirst(__ubuf__ T *goUb, __ubuf__ T *loUb,
+    __simd_vf__ static inline void AddDivFuncLastNotFirst(__ubuf__ T *goUb, __ubuf__ T *loUb,
                                                    __ubuf__ T *glUb, uint32_t row,
                                                    uint32_t col, uint32_t rowStride,
                                                    uint32_t tailCols)


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

Fixes #195

## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Fixes the Ascend 950 compilation error caused by '__simd_vf__' static member functions accessing the non‑static member rescaleThreshold. With CANN 9.2.0, the bisheng compiler enforces that functions annotated with '__simd_vf__' must be either static or free. However, simply making them static led to "invalid use of member" errors.

- Added static to relevant __simd_vf__ functions.
- Passed 'rescaleThreshold' as an explicit function parameter.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->

```
[compile-aicpu] /home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu/fa_metadata.aicpu
[compile-aicpu-cmd] bisheng -O2 -std=c++17 -fvisibility=default -fvisibility-inlines-hidden -D_GLIBCXX_USE_CXX11_ABI=0 -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/asc/include/aicpu_api -I/home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu --cce-aicpu-L/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/lib64/device/lib64 --cce-aicpu-laicpu_api --cce-aicpu-toolkit-path=/usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/bin --cce-aicpu-sysroot=/usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/sysroot -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0 -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0/aarch64-target-linux-gnu -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0/backward -c -o build/lib.linux-aarch64-cpython-310/flash_attn_npu/fa_metadata.o -x aicpu /home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu/fa_metadata.aicpu
AICPU compilation successful! output: build/lib.linux-aarch64-cpython-310/flash_attn_npu/fa_metadata.o
[compile-aicpu] /home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu_3/fa_metadata.aicpu
[compile-aicpu-cmd] bisheng -O2 -std=c++17 -fvisibility=default -fvisibility-inlines-hidden -D_GLIBCXX_USE_CXX11_ABI=0 -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/asc/include/aicpu_api -I/home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu_3 --cce-aicpu-L/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/lib64/device/lib64 --cce-aicpu-laicpu_api --cce-aicpu-toolkit-path=/usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/bin --cce-aicpu-sysroot=/usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/sysroot -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0 -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0/aarch64-target-linux-gnu -isystem /usr/local/Ascend/cann-9.2.0-beta.1/toolkit/toolchain/hcc/aarch64-target-linux-gnu/include/c++/7.3.0/backward -c -o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/fa_metadata.o -x aicpu /home/xieyh/Code/compile/flash-attention-npu/csrc/ascend910/flash_attn_npu_3/fa_metadata.aicpu
AICPU compilation successful! output: build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/fa_metadata.o
[compile-aicpu-skip] /home/xieyh/Code/compile/flash-attention-npu/csrc/ascend950/flash_attn_npu_3/fa_metadata.aicpu (obj up-to-date)
[link] build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.cpython-310-aarch64-linux-gnu.so
[link-cmd] bisheng --npu-arch=dav-2201 -shared -fPIC build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/varlen_bwd_dispatch_fp16.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/varlen_bwd_dispatch_bf16.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fag_general_host.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/flash_api.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fag_general_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fag_general_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fag_general_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fag_general_dispatch_bf16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fwd_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fwd_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fwd_dispatch_bf16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.flash_attn_npu.objs/fwd_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu/fa_metadata.o -L/usr/local/Ascend/cann-9.2.0-beta.1/compiler/lib64 -L/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/lib64 -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/share/cmake/Torch/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch_npu/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/lib -L/usr/local/Ascend/cann-9.2.0-beta.1/lib64 -lascendcl -ltorch_npu -ltiling_api -lplatform -o build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.cpython-310-aarch64-linux-gnu.so
Link successful! output: build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.cpython-310-aarch64-linux-gnu.so
[link] build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.cpython-310-aarch64-linux-gnu.so
[link-cmd] bisheng --npu-arch=dav-2201 -shared -fPIC build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/flash_api.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/fwd_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/fwd_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/fwd_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/fwd_dispatch_bf16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/bwd_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/bwd_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/bwd_dispatch_bf16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.flash_attn_npu_3.objs/bwd_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/fa_metadata.o -L/usr/local/Ascend/cann-9.2.0-beta.1/compiler/lib64 -L/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/lib64 -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/share/cmake/Torch/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch_npu/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/lib -L/usr/local/Ascend/cann-9.2.0-beta.1/lib64 -lascendcl -ltorch_npu -ltiling_api -lplatform -o build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.cpython-310-aarch64-linux-gnu.so
Link successful! output: build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.cpython-310-aarch64-linux-gnu.so
[link-skip] build/lib.linux-aarch64-cpython-310/flash_attn_npu_3_950.cpython-310-aarch64-linux-gnu.so (.so up-to-date)
[link] build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.cpython-310-aarch64-linux-gnu.so
[link-cmd] bisheng --npu-arch=dav-2201 -shared -fPIC build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/flash_api.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/fwd_dispatch_bf16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/fwd_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/fwd_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/fwd_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/bwd_dispatch_bf16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/bwd_dispatch_fp16_tnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/bwd_dispatch_fp16_bsnd.o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.flash_attn_npu_4.objs/bwd_dispatch_bf16_tnd.o -L/usr/local/Ascend/cann-9.2.0-beta.1/compiler/lib64 -L/usr/local/Ascend/cann-9.2.0-beta.1/aarch64-linux/lib64 -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/share/cmake/Torch/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch_npu/lib -L/data0/xieyh/miniconda3/cann-9.2.0/lib/python3.10/site-packages/torch/lib -L/usr/local/Ascend/cann-9.2.0-beta.1/lib64 -lascendcl -ltorch_npu -ltiling_api -lplatform -o build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.cpython-310-aarch64-linux-gnu.so
Link successful! output: build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.cpython-310-aarch64-linux-gnu.so
[link-skip] build/lib.linux-aarch64-cpython-310/flash_attn_npu_4_950.cpython-310-aarch64-linux-gnu.so (.so up-to-date)
copying build/lib.linux-aarch64-cpython-310/flash_attn_npu/flash_attn_npu.cpython-310-aarch64-linux-gnu.so -> flash_attn_npu
copying build/lib.linux-aarch64-cpython-310/flash_attn_npu_3/flash_attn_npu_3.cpython-310-aarch64-linux-gnu.so -> flash_attn_npu_3
copying build/lib.linux-aarch64-cpython-310/flash_attn_npu_3_950.cpython-310-aarch64-linux-gnu.so -> 
copying build/lib.linux-aarch64-cpython-310/flash_attn_npu_4/flash_attn_npu_4.cpython-310-aarch64-linux-gnu.so -> flash_attn_npu_4
copying build/lib.linux-aarch64-cpython-310/flash_attn_npu_4_950.cpython-310-aarch64-linux-gnu.so -> 
```

## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->
None.