### PR TITLE
fix: remove unused 950 v3 workspace placeholder allocation

### DIFF
--- a/csrc/ascend950/flash_attn_npu_3/fa_metadata.aicpu
+++ b/csrc/ascend950/flash_attn_npu_3/fa_metadata.aicpu
@@ -154,11 +154,6 @@ __global__ __aicpu__ uint32_t ComputeFAMetadata(void *args)
     tilingData->smOnlineOutSize = fa_metadata::SmOnlineOutSize(blockDim);
     tilingData->pvOutSize = fa_metadata::Mm2OutSize(blockDim);
     tilingData->UpdateSize = fa_metadata::UpdateOutSize(blockDim);
-    uint64_t workSpaceSize = fa_metadata::WorkSpaceSize(blockDim);
-    if (workSpaceSize < fa_metadata::WS_FLOOR) {
-        workSpaceSize = fa_metadata::WS_FLOOR;
-    }
-    tilingData->workSpaceSize = workSpaceSize;
 
     if (hasMask) {
         // Same triu(1) mask the host path uploads for both causal and band/SWA;

--- a/csrc/ascend950/flash_attn_npu_3/mha_fwd.cpp
+++ b/csrc/ascend950/flash_attn_npu_3/mha_fwd.cpp
@@ -267,7 +267,6 @@ mha_fwd(at::Tensor q,
     uint8_t *tilingDevice = nullptr;
     uint8_t *maskDevice = nullptr;
     uint8_t *metaBase = nullptr;
-    uint64_t workSpaceSize = 0;
     SeqlenScratch scratch;
     optiling::FAInferContext ctx;
     FAInferTilingData tilingData{};
@@ -315,10 +314,6 @@ mha_fwd(at::Tensor q,
         metaBase = static_cast<uint8_t *>(schedMd.data_ptr());
         tilingDevice = metaBase + fa_metadata::TilingOffset(hasMask);
         maskDevice = hasMask ? metaBase : nullptr;
-        workSpaceSize = fa_metadata::WorkSpaceSize(blockDim);
-        if (workSpaceSize < fa_metadata::WS_FLOOR) {
-            workSpaceSize = fa_metadata::WS_FLOOR;
-        }
     } else {
         at::Tensor cu_seqlen_q_cpu;
         if (is_varlen_q) {
@@ -405,10 +400,6 @@ mha_fwd(at::Tensor q,
             launchBlockDim = tilingData.fdActiveCoreNum;
             combineBlockDim = tilingData.fdCombineBlockDim;
         }
-        if (tilingData.workSpaceSize < fa_metadata::WS_FLOOR) {
-            tilingData.workSpaceSize = fa_metadata::WS_FLOOR;
-        }
-        workSpaceSize = tilingData.workSpaceSize;
 
         at::Tensor tiling_cpu = at::empty(
             {static_cast<int64_t>(sizeof(FAInferTilingData))},
@@ -430,10 +421,6 @@ mha_fwd(at::Tensor q,
     // ============================================================
     // 8. Allocate output-side buffers on NPU
     // ============================================================
-    auto workspace = at::empty(
-        {static_cast<int64_t>(workSpaceSize)},
-        at::device(at::kPrivateUse1).dtype(at::kByte));
-
     at::Tensor softmaxlse = at::empty(
         {0}, at::device(at::kPrivateUse1).dtype(at::kFloat));
     if (return_softmax_lse && is_varlen_q) {
@@ -450,6 +437,12 @@ mha_fwd(at::Tensor q,
     if (flashDecodeEnabled && !return_softmax_lse) {
         fd_lse = at::empty({num_heads, sizes[0]},
                            at::device(at::kPrivateUse1).dtype(at::kFloat));
+    }
+    at::Tensor workspace;
+    if (flashDecodeEnabled) {
+        workspace = at::empty(
+            {static_cast<int64_t>(tilingData.workSpaceSize)},
+            at::device(at::kPrivateUse1).dtype(at::kByte));
     }
 
     // ============================================================
@@ -472,7 +465,10 @@ mha_fwd(at::Tensor q,
     auto lseDev = return_softmax_lse
         ? static_cast<uint8_t*>(softmaxlse.data_ptr())
         : (flashDecodeEnabled ? static_cast<uint8_t*>(fd_lse.data_ptr()) : oDev);
-    auto wsDev = static_cast<uint8_t*>(workspace.data_ptr());
+    uint8_t *wsDev = nullptr;
+    if (flashDecodeEnabled) {
+        wsDev = static_cast<uint8_t*>(workspace.data_ptr());
+    }
     auto tilDev = tilingDevice;
 
     const auto i64_npu = at::device(at::kPrivateUse1).dtype(at::kLong);


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123
https://github.com/MinghuasLab/flash-attention-npu/issues/205
Fixes #205

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->



## Summary
remove unused 950 v3 workspace placeholder allocation
<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->



## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->
<img width="435" height="462" alt="image" src="https://github.com/user-attachments/assets/8ded812a-1d02-4985-a132-876e48c77e05" />



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->