### PR TITLE
perf: fix redundant calculations brought by fd

### DIFF
--- a/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
@@ -361,11 +361,10 @@ namespace SplitFuse {
                     }
                 }
             } else if (flashDecodeFlag == 0U) {
+                uint32_t curBatchTmp = 0;
+                uint32_t preTotalTaskNumTmp = 0;
+                uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
                 for (uint32_t taskIdx = coreIdx; taskIdx < totalTaskNum; taskIdx += uint32_t(coreNum)) {
-                    uint32_t curBatchTmp = 0;
-                    uint32_t preTotalTaskNumTmp = 0;
-                    uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
-
                     while (taskIdx >= curTotalTaskNumTmp) {
                         ++curBatchTmp;
                         preTotalTaskNumTmp = curTotalTaskNumTmp;
@@ -542,11 +541,8 @@ namespace SplitFuse {
                         // Capacity-aligned cache: cache batch occupies [BIdx * kvCacheSeqlen, ...).
                         prevKvSeqlenSum = BIdx * kvCacheSeqlen;
                     } else {
-                        // Mirror mha_fwd_kvcache_2.cpp semantics: per-batch K/V step
-                        // uses each batch's actual kvSeqlen (prefix sum across batches).
-                        for (uint32_t b = 0; b < BIdx; b++) {
-                            prevKvSeqlenSum += static_cast<uint32_t>(gActualKvseqlen.GetValue(b));
-                        }
+                        // BSND K seqlens are not variable, just multiply by the batch index to get the offset.
+                        prevKvSeqlenSum = static_cast<uint32_t>(gActualKvseqlen.GetValue(0)) * BIdx;
                     }
                 }
             }

--- a/csrc/ascend910/flash_attn_npu_3/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu_3/mha_fwd_kvcache.cpp
@@ -344,11 +344,10 @@ namespace SplitFuse {
                     }
                 }
             } else if (flashDecodeFlag == 0U) {
+                uint32_t curBatchTmp = 0;
+                uint32_t preTotalTaskNumTmp = 0;
+                uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
                 for (uint32_t taskIdx = coreIdx; taskIdx < totalTaskNum; taskIdx += uint32_t(coreNum)) {
-                    uint32_t curBatchTmp = 0;
-                    uint32_t preTotalTaskNumTmp = 0;
-                    uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
-
                     while (taskIdx >= curTotalTaskNumTmp) {
                         ++curBatchTmp;
                         preTotalTaskNumTmp = curTotalTaskNumTmp;
@@ -524,11 +523,8 @@ namespace SplitFuse {
                         // Capacity-aligned cache: cache batch occupies [BIdx * kvCacheSeqlen, ...).
                         prevKvSeqlenSum = BIdx * kvCacheSeqlen;
                     } else {
-                        // Mirror mha_fwd_kvcache_2.cpp semantics: per-batch K/V step
-                        // uses each batch's actual kvSeqlen (prefix sum across batches).
-                        for (uint32_t b = 0; b < BIdx; b++) {
-                            prevKvSeqlenSum += static_cast<uint32_t>(gActualKvseqlen.GetValue(b));
-                        }
+                        // BSND K seqlens are not variable, just multiply by the batch index to get the offset.
+                        prevKvSeqlenSum = static_cast<uint32_t>(gActualKvseqlen.GetValue(0)) * BIdx;
                     }
                 }
             }

--- a/csrc/ascend910/flash_attn_npu_4/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu_4/mha_fwd_kvcache.cpp
@@ -320,11 +320,10 @@ namespace SplitFuse {
                     }
                 }
             } else if (flashDecodeFlag == 0U) {
+                uint32_t curBatchTmp = 0;
+                uint32_t preTotalTaskNumTmp = 0;
+                uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
                 for (uint32_t taskIdx = coreIdx; taskIdx < totalTaskNum; taskIdx += uint32_t(coreNum)) {
-                    uint32_t curBatchTmp = 0;
-                    uint32_t preTotalTaskNumTmp = 0;
-                    uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
-
                     while (taskIdx >= curTotalTaskNumTmp) {
                         ++curBatchTmp;
                         preTotalTaskNumTmp = curTotalTaskNumTmp;
@@ -484,11 +483,8 @@ namespace SplitFuse {
                 // BSND: Q/O/LSE per-batch storage step is maxQSeqlen.
                 prevQSeqlenSum = BIdx * maxQSeqlen;
                 if constexpr (!PAGED_CACHE_FLAG) {
-                    // Mirror mha_fwd_kvcache_2.cpp semantics: per-batch K/V step
-                    // uses each batch's actual kvSeqlen (prefix sum across batches).
-                    for (uint32_t b = 0; b < BIdx; b++) {
-                        prevKvSeqlenSum += static_cast<uint32_t>(gActualKvseqlen.GetValue(b));
-                    }
+                    // BSND K seqlens are not variable, just multiply by the batch index to get the offset.
+                    prevKvSeqlenSum = static_cast<uint32_t>(gActualKvseqlen.GetValue(0)) * BIdx;
                 }
             }
 


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

Fixes #207 

## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

Optimized non-flashdecoding forward path in 910B v2/v3/v4
- Moved tiling accumulators `(curBatchTmp,` etc.) outside the `taskIdx` loop.
- Adopted a different approach for `prevKvSeqlenSum.`

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->

Performance was validated on large‑batch, small‑seqlen workloads (e.g., `batch_size=1024`, `seqlen=128`, `nheads=24`, `nheadskv=4`, `headdim=128`). End‑to‑end latency improved from `19ms` to `6.6ms` with these changes.
<img width="1388" height="295" alt="image" src="https://github.com/user-attachments/assets/a191a663-fbda-462a-a378-126dc6756985" />


## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->

The performance numbers reported above do not account for performance regressions from other commits on the main branch. This optimization only addresses the negative impact introduced by the FD V2 commit(https://github.com/MinghuasLab/flash-attention-npu/pull/13/commits/6b23209c4181b52c8de566ebf142845e4f312b90). After applying this fix, the same test case takes ~`10ms` on main branch, indicating that further optimization opportunities remain.