### PR TITLE
fix: correct Ascend 910 SWA bounds and invalid-row clearing

### DIFF
--- a/csrc/ascend910/flash_attn_npu/alibi.hpp
+++ b/csrc/ascend910/flash_attn_npu/alibi.hpp
@@ -41,7 +41,8 @@ __aicore__ inline void BuildAlibiBiasRow(AscendC::LocalTensor<float> &workUb,
     }
     
     if (baseColIdx < 0) {
-        AscendC::Abs(workUb, workUb, AscendC::Std::min(-baseColIdx, count));
+        AscendC::Abs(workUb, workUb,
+            AscendC::Std::min(-baseColIdx, static_cast<int64_t>(count)));
         AscendC::PipeBarrier<PIPE_V>();
     }
 }

--- a/csrc/ascend910/flash_attn_npu/fa_metadata.aicpu
+++ b/csrc/ascend910/flash_attn_npu/fa_metadata.aicpu
@@ -81,6 +81,21 @@ __global__ __aicpu__ uint32_t ComputeFAMetadataV2(void *args)
     }
     tilingData->maxKvSeqlen = maxKvSeqlen;
 
+    // A declared KV bound can exceed every actual per-batch length. Clamp a
+    // local side that already covers the actual maximum; this preserves the
+    // mask semantics while retaining MASK_BAND for stable host dispatch.
+    if (metaArgs->maskType == MASK_TYPE_BAND && maxKvSeqlen > 0) {
+        const int64_t actualMaxKv = static_cast<int64_t>(maxKvSeqlen);
+        if (tilingData->windowSizeLeft < 0 ||
+            tilingData->windowSizeLeft >= actualMaxKv) {
+            tilingData->windowSizeLeft = actualMaxKv;
+        }
+        if (tilingData->windowSizeRight < 0 ||
+            tilingData->windowSizeRight >= actualMaxKv) {
+            tilingData->windowSizeRight = actualMaxKv;
+        }
+    }
+
     const uint64_t blockDim = static_cast<uint64_t>(metaArgs->blockDim);
     tilingData->mm1OutSize = fa_metadata::Mm1OutSize(blockDim);
     tilingData->smOnlineOutSize = fa_metadata::SmOnlineOutSize(blockDim);

--- a/csrc/ascend910/flash_attn_npu/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu/flash_api.cpp
@@ -1541,8 +1541,8 @@ at::Tensor get_scheduler_metadata(
         cuSeqlensQDev = cu_q.data_ptr();
     }
     TORCH_CHECK(cache_seqlens.dtype() == torch::kInt32, "cache_seqlens must have dtype int32");
+    TORCH_CHECK(!page_size.has_value() || page_size.value() > 0, "page_size must be positive");
     const uint32_t ps = page_size.has_value() ? static_cast<uint32_t>(page_size.value()) : 128;
-    TORCH_CHECK(!page_size.has_value() || ps > 0, "page_size must be positive");
     const uint32_t blockDim = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAic();
     TORCH_CHECK(softcap >= 0.0, "softcap must be non-negative (0.0 disables softcap)");
     // Mask axes are fully derived on host from the declared seqlen bounds; the

--- a/csrc/ascend910/flash_attn_npu/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu/flash_api.cpp
@@ -70,14 +70,11 @@ struct FwdMaskDerivation {
     uint32_t maskType;
 };
 
-// Window normalization + mask-type derivation, mirroring the host tiling code,
-// but bounding the KV side with a host-known upper bound (cache capacity)
-// instead of the device-side actual max KV seqlen, so it is usable on the
-// scheduler-metadata path where no D2H sync is allowed. Both sides compare
-// against the KV bound (matching the host's "both sides vs seqlen_k" rule);
-// an over-long window collapses to "no window", and a window that covers the
-// whole sequence masks nothing, so a bound larger than the actual seqlen is
-// still semantically identical.
+// Window normalization + mask-type derivation, mirroring the host tiling code.
+// The caller provides the logical KV bound (or cache capacity for the KV-cache
+// API), so this path does not need a D2H sync to inspect the actual lengths.
+// Both sides compare against the KV bound, matching the host's
+// "both sides vs seqlen_k" rule.
 static FwdMaskDerivation DeriveFwdMask(bool causal, int64_t window_left, int64_t window_right,
                                        int64_t /*max_seqlen_q*/, int64_t max_seqlen_k_bound)
 {
@@ -162,46 +159,57 @@ static at::Tensor GetSchedulerMetadataImpl(FAMetadataArgs args,
     return meta;
 }
 
-// async copy dropout tiling data
-static void PatchTilingDropoutFields(const at::Tensor &schedMd, uint64_t tilingOffset,
+// Patch fields that are only known by the forward consuming the metadata.
+// The copies run on the current stream after the AICPU metadataDone event.
+static void PatchTilingRuntimeFields(const at::Tensor &schedMd, uint64_t tilingOffset,
                                      float dropoutValue, uint8_t *pDevice,
-                                     uint8_t *dropMaskDevice)
+                                     uint8_t *dropMaskDevice,
+                                     std::optional<uint32_t> maxNumBlocksPerBatch = std::nullopt)
 {
-    if (dropMaskDevice == nullptr) {
+    if (dropMaskDevice == nullptr && !maxNumBlocksPerBatch.has_value()) {
         return;
     }
-    struct DropFields {
+    struct RuntimeFields {
         float dropoutValue;
+        uint32_t maxNumBlocksPerBatch;
         uint64_t pDevice;
         uint64_t dropMaskDevice;
     };
     // The Host2Device staging copy is async and reads the source after this function
     // returns; static + same-stream serialization keeps it alive and safe.
     static at::Tensor patchDev;
-    static DropFields fields;
+    static RuntimeFields fields;
     if (!patchDev.defined()) {
-        patchDev = torch::empty({static_cast<int64_t>(sizeof(DropFields))},
+        patchDev = torch::empty({static_cast<int64_t>(sizeof(RuntimeFields))},
                                 at::device(at::kPrivateUse1).dtype(at::kByte));
     }
     fields.dropoutValue = dropoutValue;
+    fields.maxNumBlocksPerBatch = maxNumBlocksPerBatch.value_or(0);
     fields.pDevice = reinterpret_cast<uint64_t>(pDevice);
     fields.dropMaskDevice = reinterpret_cast<uint64_t>(dropMaskDevice);
 
-    at::Tensor patchCpu = torch::from_blob(&fields, {static_cast<int64_t>(sizeof(DropFields))},
+    at::Tensor patchCpu = torch::from_blob(&fields, {static_cast<int64_t>(sizeof(RuntimeFields))},
                                            at::TensorOptions().dtype(torch::kUInt8));
     patchDev.copy_(patchCpu);  // H2D staging, current stream
 
     auto tilingView = schedMd.narrow(0, static_cast<int64_t>(tilingOffset),
                                      static_cast<int64_t>(sizeof(FAInferTilingData)));
-    tilingView.narrow(0, offsetof(FAInferTilingData, dropoutValue), 4)
-        .view(torch::kFloat32)
-        .copy_(patchDev.narrow(0, offsetof(DropFields, dropoutValue), 4).view(torch::kFloat32));
-    tilingView.narrow(0, offsetof(FAInferTilingData, pDevice), 8)
-        .view(torch::kInt64)
-        .copy_(patchDev.narrow(0, offsetof(DropFields, pDevice), 8).view(torch::kInt64));
-    tilingView.narrow(0, offsetof(FAInferTilingData, dropMaskDevice), 8)
-        .view(torch::kInt64)
-        .copy_(patchDev.narrow(0, offsetof(DropFields, dropMaskDevice), 8).view(torch::kInt64));
+    if (dropMaskDevice != nullptr) {
+        tilingView.narrow(0, offsetof(FAInferTilingData, dropoutValue), 4)
+            .view(torch::kFloat32)
+            .copy_(patchDev.narrow(0, offsetof(RuntimeFields, dropoutValue), 4).view(torch::kFloat32));
+        tilingView.narrow(0, offsetof(FAInferTilingData, pDevice), 8)
+            .view(torch::kInt64)
+            .copy_(patchDev.narrow(0, offsetof(RuntimeFields, pDevice), 8).view(torch::kInt64));
+        tilingView.narrow(0, offsetof(FAInferTilingData, dropMaskDevice), 8)
+            .view(torch::kInt64)
+            .copy_(patchDev.narrow(0, offsetof(RuntimeFields, dropMaskDevice), 8).view(torch::kInt64));
+    }
+    if (maxNumBlocksPerBatch.has_value()) {
+        tilingView.narrow(0, offsetof(FAInferTilingData, maxNumBlocksPerBatch), 4)
+            .view(torch::kInt32)
+            .copy_(patchDev.narrow(0, offsetof(RuntimeFields, maxNumBlocksPerBatch), 4).view(torch::kInt32));
+    }
 }
 
 std::vector<at::Tensor>
@@ -758,7 +766,7 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
                                      at::device(at::kPrivateUse1).dtype(at::kByte));
         // The AICPU tiling does not carry the dropout fields; patch them in
         // with stream-ordered copies (after the AICPU metadataDone event).
-        PatchTilingDropoutFields(schedMd, fa_metadata::TilingOffset(hasMask),
+        PatchTilingRuntimeFields(schedMd, fa_metadata::TilingOffset(hasMask),
                                  1.0f / (1.0f - p_dropout),
                                  return_softmax ? static_cast<uint8_t *>(const_cast<void *>(p.data_ptr())) : nullptr,
                                  has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr);
@@ -1066,12 +1074,14 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         maskDevice = hasMask ? metaBase : nullptr;
         workspace_tensor = at::empty({static_cast<int64_t>(fa_metadata::WorkSpaceSize(blockDim))},
                                      at::device(at::kPrivateUse1).dtype(at::kByte));
-        // Same dropout patch as mha_fwd: stream-ordered copies fill the
-        // AICPU tiling's missing dropout fields.
-        PatchTilingDropoutFields(schedMd, fa_metadata::TilingOffset(hasMask),
+        // Dropout pointers and the physical page-table row width are only
+        // available at forward time; patch them after AICPU metadata creation.
+        PatchTilingRuntimeFields(schedMd, fa_metadata::TilingOffset(hasMask),
                                  1.0f / (1.0f - p_dropout),
                                  return_softmax ? static_cast<uint8_t *>(const_cast<void *>(p.data_ptr())) : nullptr,
-                                 has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr);
+                                 has_dropout ? static_cast<uint8_t *>(const_cast<void *>(drop_mask_npu_tensor.data_ptr())) : nullptr,
+                                 paged_KV ? std::optional<uint32_t>(static_cast<uint32_t>(max_num_blocks_per_seq))
+                                          : std::nullopt);
     } else {
         at::Tensor tiling_cpu_tensor = at::empty({static_cast<int64_t>(sizeof(FAInferTilingData))},
                                                 at::device(c10::kCPU).dtype(at::kByte));
@@ -1532,6 +1542,7 @@ at::Tensor get_scheduler_metadata(
     }
     TORCH_CHECK(cache_seqlens.dtype() == torch::kInt32, "cache_seqlens must have dtype int32");
     const uint32_t ps = page_size.has_value() ? static_cast<uint32_t>(page_size.value()) : 128;
+    TORCH_CHECK(!page_size.has_value() || ps > 0, "page_size must be positive");
     const uint32_t blockDim = platform_ascendc::PlatformAscendCManager::GetInstance()->GetCoreNumAic();
     TORCH_CHECK(softcap >= 0.0, "softcap must be non-negative (0.0 disables softcap)");
     // Mask axes are fully derived on host from the declared seqlen bounds; the

--- a/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu/mha_fwd_kvcache.cpp
@@ -700,7 +700,8 @@ namespace SplitFuse {
                 kvStartOld = CeilDiv(kvSeqlenOld, MAX_KV_STACK_LEN);
                 kvSLoopNumTotalOld = CeilDiv(
                     AscendC::Std::max((int64_t)0,
-                        AscendC::Std::min(noSkipKvS, (int64_t)kvSeqlenOld)),
+                        AscendC::Std::min(static_cast<int64_t>(noSkipKvS),
+                            static_cast<int64_t>(kvSeqlenOld))),
                     (int64_t)MAX_KV_STACK_LEN);
                 kvLoopNumTotalNew = CeilDiv(kvNewSeqlen, MAX_KV_STACK_LEN);
                 kvSLoopNumTotal = kvSLoopNumTotalOld + kvLoopNumTotalNew;

--- a/csrc/ascend910/flash_attn_npu/rescale_o.hpp
+++ b/csrc/ascend910/flash_attn_npu/rescale_o.hpp
@@ -190,6 +190,50 @@ public:
     }
 
     __aicore__ inline
+    void ClearInvalidOutputRows(
+        uint32_t ubRowOffset, uint32_t tokenStart, uint32_t tokenNum,
+        int32_t delStartRow, int32_t delEndRow, uint32_t qSeqlen, uint32_t embedRound)
+    {
+        if (tokenNum == 0U) {
+            return;
+        }
+
+        // delStartRow marks an invalid suffix [delStartRow, qSeqlen).
+        if (delStartRow > 0) {
+            uint32_t suffixStart = static_cast<uint32_t>(delStartRow);
+            uint32_t localStart = 0U;
+            if (tokenStart < suffixStart) {
+                uint32_t validPrefix = suffixStart - tokenStart;
+                localStart = validPrefix < tokenNum ? validPrefix : tokenNum;
+            }
+            if (localStart < tokenNum) {
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Duplicate<ElementOutput>(
+                    goUbTensor16[(ubRowOffset + localStart) * embedRound],
+                    static_cast<ElementOutput>(0),
+                    (tokenNum - localStart) * embedRound);
+            }
+        }
+
+        // delEndRow marks an invalid prefix [0, delEndRow).
+        if (delEndRow >= 0 && delEndRow != static_cast<int32_t>(qSeqlen)) {
+            uint32_t prefixEnd = static_cast<uint32_t>(delEndRow);
+            uint32_t localEnd = 0U;
+            if (tokenStart < prefixEnd) {
+                uint32_t invalidPrefix = prefixEnd - tokenStart;
+                localEnd = invalidPrefix < tokenNum ? invalidPrefix : tokenNum;
+            }
+            if (localEnd > 0U) {
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Duplicate<ElementOutput>(
+                    goUbTensor16[ubRowOffset * embedRound],
+                    static_cast<ElementOutput>(0),
+                    localEnd * embedRound);
+            }
+        }
+    }
+
+    __aicore__ inline
     void CopyOToGm(AscendC::GlobalTensor<ElementOutput> gOutput, uint32_t proTokenIdx, uint32_t proTokenNum,
         uint32_t epiTokenNum, uint32_t integralHeadNum, uint32_t qSThisSubBlock, uint32_t embed, uint32_t embedRound, uint32_t oHiddenSize)
     {
@@ -423,83 +467,31 @@ public:
                 }
             }
             uint32_t rowStart = qSBlockIdx * VECTOR_SIZE + rowOffsetCurLoop ;
-            uint32_t innerGOUbOffset = 0;
             uint32_t subBlockStart = (curQNBlockTile == 1U) ? rowStart  : (rowStart >= qSeqlen ? rowStart - rowStart / qSeqlen * qSeqlen : rowStart);
-            if (delStartRow != 0) {
-                if (proTokenNum != 0U && subBlockStart + proTokenNum >= delStartRow) {
-                    uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
-                    uint32_t end = proTokenNum;
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Duplicate<ElementOutput>(
-                        goUbTensor16[innerGOUbOffset + start * embedRound],
-                        static_cast<ElementOutput>(0),
-                        (end - start) * embedRound
-                    );
-                    innerGOUbOffset += proTokenNum * embedRound;
-                }
-                if (subBlockStart + qSThisSubBlock >= delStartRow) {
-                    for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
-                        uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
-                        uint32_t end = qSThisSubBlock;
-                        AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Duplicate<ElementOutput>(
-                            goUbTensor16[innerGOUbOffset + start  * embedRound],
-                            static_cast<ElementOutput>(0),
-                            (end - start) * embedRound
-                        );
-                        innerGOUbOffset += qSThisSubBlock * embedRound;
+            if (!splitParams.isSplitkv) {
+                if (curQNBlockTile == 1U) {
+                    ClearInvalidOutputRows(
+                        0U, rowStart, curRowNum, delStartRow, delEndRow, qSeqlen, embedRound);
+                } else {
+                    uint32_t innerGOUbRowOffset = 0U;
+                    uint32_t qBlockStart = qSBlockIdx * VECTOR_SIZE;
+                    if (proTokenNum != 0U) {
+                        ClearInvalidOutputRows(
+                            innerGOUbRowOffset, subBlockStart, proTokenNum,
+                            delStartRow, delEndRow, qSeqlen, embedRound);
+                        innerGOUbRowOffset += proTokenNum;
                     }
-                }
-                if (epiTokenNum != 0U && subBlockStart + epiTokenNum >= delStartRow) {
-                    uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
-                    uint32_t end = epiTokenNum;
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Duplicate<ElementOutput>(
-                        goUbTensor16[innerGOUbOffset + start * embedRound],
-                        static_cast<ElementOutput>(0),
-                        (end - start) * embedRound
-                    );
-                }
-            }
-            if (delEndRow != qSeqlen) {
-                if (proTokenNum != 0U && subBlockStart < delEndRow) {
-                    uint32_t start = curQNBlockTile == 1U ? rowStart : 0;
-                    uint32_t end = (subBlockStart + proTokenNum >= delEndRow) ?
-                                                    (curQNBlockTile == 1U ? delEndRow : delEndRow - subBlockStart)
-                                                            : subBlockStart + proTokenNum;
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Duplicate<ElementOutput>(
-                        goUbTensor16[innerGOUbOffset],
-                        static_cast<ElementOutput>(0),
-                        (end - start) * embedRound
-                    );
-                    innerGOUbOffset += proTokenNum * embedRound;
-                }
-                if (subBlockStart < delEndRow) {
-                    for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
-                        uint32_t start = curQNBlockTile == 1U ? subBlockStart : proTokenNum;
-                        uint32_t end = (subBlockStart + qSThisSubBlock >= delEndRow) ?
-                                            (curQNBlockTile == 1U ? delEndRow : delEndRow - subBlockStart)
-                                                         : start + qSThisSubBlock;
-                        AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Duplicate<ElementOutput>(
-                            goUbTensor16[innerGOUbOffset],
-                            static_cast<ElementOutput>(0),
-                            (end - start) * embedRound
-                        );
-                        innerGOUbOffset += qSThisSubBlock * embedRound;
+                    for (uint32_t qNIdx = 0U; qNIdx < integralHeadNum; qNIdx++) {
+                        ClearInvalidOutputRows(
+                            innerGOUbRowOffset, qBlockStart, qSThisSubBlock,
+                            delStartRow, delEndRow, qSeqlen, embedRound);
+                        innerGOUbRowOffset += qSThisSubBlock;
                     }
-                }
-                if (epiTokenNum != 0U && subBlockStart < delEndRow) {
-                    uint32_t start = curQNBlockTile == 1U ? subBlockStart : proTokenNum + integralHeadNum * qSThisSubBlock + subBlockStart;
-                    uint32_t end = curQNBlockTile == 1U ? (subBlockStart + epiTokenNum >= delEndRow ? delEndRow : subBlockStart + epiTokenNum) :
-                                            (epiTokenNum >= delEndRow ? start + delEndRow: start + epiTokenNum);
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Duplicate<ElementOutput>(
-                        goUbTensor16[innerGOUbOffset],
-                        static_cast<ElementOutput>(0),
-                        (end - start) * embedRound
-                    );
+                    if (epiTokenNum != 0U) {
+                        ClearInvalidOutputRows(
+                            innerGOUbRowOffset, qBlockStart, epiTokenNum,
+                            delStartRow, delEndRow, qSeqlen, embedRound);
+                    }
                 }
             }
 

--- a/flash_attn_npu/flash_attn_npu_interface.py
+++ b/flash_attn_npu/flash_attn_npu_interface.py
@@ -964,22 +964,20 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         num_heads, head_size = q.shape[1], q.shape[2]
         if block_table is not None:
             # Paged KV: k/v are (num_blocks, page_size, num_heads_k, headdim);
-            # the metadata seqlen bound is the cache capacity, matching the
-            # flash_attn_with_kvcache contract.
+            # scheduler metadata uses the logical max KV length for SWA. The
+            # physical page-table stride is supplied by mha_varlen_fwd.
             page_size = k.shape[1]
             num_heads_k = k.shape[2]
-            metadata_max_seqlen_k = block_table.shape[1] * page_size
         else:
             page_size = None
             num_heads_k = k.shape[1]
-            metadata_max_seqlen_k = max_seqlen_k
         cache_seqlens = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
         if alibi_slopes is None:
             alibi_slopes_batch_stride = 0
         else:
             alibi_slopes_batch_stride = alibi_slopes.shape[1] if alibi_slopes.dim() == 2 else 0
         scheduler_metadata = get_scheduler_metadata(
-            batch_size, max_seqlen_q, metadata_max_seqlen_k, num_heads, num_heads_k, head_size,
+            batch_size, max_seqlen_q, max_seqlen_k, num_heads, num_heads_k, head_size,
             cache_seqlens,
             qkv_dtype=q.dtype,
             cu_seqlens_q=cu_seqlens_q,
@@ -1759,7 +1757,7 @@ def get_scheduler_metadata(
     window_size=(-1, -1),  # -1 means infinite context window
     softcap=0.0,   # 0.0 means deactivated
     softmax_scale=None,  # defaults to 1 / sqrt(headdim); must match the fwd call
-    alibi_slopes_batch_stride=0,  
+    alibi_slopes_batch_stride=0,
 ):
     """Precompute the forward scheduler metadata (tiling, optional mask, and —
     for paged KV cache — the flash-decode split schedule) on the AICPU. Pass the

--- a/tests/test_flash_attn_npu_v2.py
+++ b/tests/test_flash_attn_npu_v2.py
@@ -603,6 +603,10 @@ varlen_cases = [
     (torch.float16, 5, 5, 1, 777, 888, 128, True, -1, -1, 0.0, 0, 128, 0.2, False),
     (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, True, -1, -1, 30.0, 0, 128, 0.1, False),
     (torch.float16, 2, 4, 2, 512, 512, 128, False, -1, -1, 0.0, 1, 128, 0.3, False),
+    # Issue #196 (Ascend 910): paged-varlen metadata must normalize SWA with
+    # the logical max KV length rather than the page-aligned cache capacity.
+    (torch.bfloat16, 2, 4, 2, 256, 512, 128, False, 511, 0, 0.0, 1, 128, 0.0, False),
+    (torch.bfloat16, 8, 48, 4, 513, 511, 111, False, 511, 0, 0.0, 1, 128, 0.0, False),
     # Dropout backward regression cases from the former standalone v2_bwd test.
     (torch.bfloat16, 3, 1, 1, 512, 1024, 128, True, -1, -1, 0.0, 0, 128, 0.3, False),
     (torch.float16, 5, 5, 1, 777, 888, 128, False, -1, -1, 0.0, 0, 128, 0.2, False),
@@ -746,3 +750,160 @@ def test_fa_varlen_ops(data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_
         assert_fa_close(dq_ag, dq_ref, dq_pt, softcap=softcap, name="dQ")
         assert_fa_close(dk_ag, dk_ref, dk_pt, softcap=softcap, name="dK")
         assert_fa_close(dv_ag, dv_ref, dv_pt, softcap=softcap, name="dV")
+
+
+def test_fa_varlen_paged_swa_overprovisioned_block_table():
+    """V2 forward must use the physical block-table row width for paging."""
+
+    data_type = torch.bfloat16
+    seqlens_q, seqlens_k = [17, 11], [129, 65]
+    max_seqlen_q, max_seqlen_k = max(seqlens_q), max(seqlens_k)
+    batch_size, num_heads, kv_heads, head_size, block_size = 2, 2, 1, 64, 64
+    logical_blocks = (max_seqlen_k + block_size - 1) // block_size
+    block_table_width = logical_blocks + 2
+    num_blocks = batch_size * block_table_width
+    generator = torch.Generator().manual_seed(196)
+
+    query = make_packed_random_tensor(
+        seqlens_q, max_seqlen_q, num_heads, head_size, data_type,
+        generator=generator, device="npu",
+    )
+    key = make_random_tensor(
+        (num_blocks, block_size, kv_heads, head_size), data_type,
+        generator=generator, device="npu",
+    )
+    value = make_random_tensor(
+        (num_blocks, block_size, kv_heads, head_size), data_type,
+        generator=generator, device="npu",
+    )
+    block_table = torch.arange(num_blocks, dtype=torch.int32).reshape(
+        batch_size, block_table_width
+    ).npu()
+    cu_q, cu_k = make_cu_seqlens(seqlens_q), make_cu_seqlens(seqlens_k)
+    scale = head_size ** -0.5
+    window_size = (max_seqlen_k, 0)
+
+    output_npu = flash_attn_varlen_func(
+        query,
+        key,
+        value,
+        cu_q.npu(),
+        cu_k.npu(),
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale=scale,
+        causal=False,
+        window_size=window_size,
+        block_table=block_table,
+    )
+
+    query_ref = query.cpu()
+    key_ref = key.cpu()
+    value_ref = value.cpu()
+    query_padded = pad_packed_tensor(query_ref, seqlens_q, max_seqlen_q)
+    key_padded, value_padded = gather_paged_kv_batch(
+        key_ref, value_ref, block_table.cpu(), max_seqlen_k, block_size
+    )
+    q_valid, _, atten_mask = make_padded_varlen_mask(
+        seqlens_q,
+        seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        False,
+        *window_size,
+    )
+    golden_out_ref, _, golden_out_pt, _ = ref_flash_attention_pair(
+        query_padded,
+        key_padded,
+        value_padded,
+        scale,
+        atten_mask,
+        data_type,
+        0.0,
+    )
+    fully_masked = atten_mask.all(dim=-1)
+    golden_out_ref[fully_masked] = 0
+    golden_out_pt[fully_masked] = 0
+    assert_fa_close(
+        output_npu,
+        golden_out_ref[q_valid],
+        golden_out_pt[q_valid],
+        name="paged_swa_overprovisioned_block_table_out",
+    )
+
+
+def test_fa_varlen_swa_invalid_prefix_clear_regression():
+    """ATK SWA #146: guard multi-head output clearing for q_len > kv_len."""
+
+    seqlens_q = [43, 21]
+    seqlens_k = [512, 1]
+    max_seqlen_q, max_seqlen_k = max(seqlens_q), max(seqlens_k)
+    num_heads, kv_heads, head_size = 8, 1, 224
+    window_size = (511, 0)
+    softcap = 1.0
+    generator = torch.Generator().manual_seed(146)
+    query = make_packed_random_tensor(
+        seqlens_q, max_seqlen_q, num_heads, head_size, torch.bfloat16,
+        generator=generator, device="npu",
+    )
+    key = make_packed_random_tensor(
+        seqlens_k, max_seqlen_k, kv_heads, head_size, torch.bfloat16,
+        generator=generator, device="npu",
+    )
+    value = make_packed_random_tensor(
+        seqlens_k, max_seqlen_k, kv_heads, head_size, torch.bfloat16,
+        generator=generator, device="npu",
+    )
+    cu_q, cu_k = make_cu_seqlens(seqlens_q), make_cu_seqlens(seqlens_k)
+
+    output_npu = flash_attn_varlen_func(
+        query,
+        key,
+        value,
+        cu_q.npu(),
+        cu_k.npu(),
+        max_seqlen_q,
+        max_seqlen_k,
+        dropout_p=0.0,
+        softmax_scale=0.0,
+        causal=False,
+        window_size=window_size,
+        softcap=softcap,
+        deterministic=True,
+        return_attn_probs=False,
+    )
+
+    query_ref = query.cpu()
+    key_ref = key.cpu()
+    value_ref = value.cpu()
+    query_padded = pad_packed_tensor(query_ref, seqlens_q, max_seqlen_q)
+    key_padded = pad_packed_tensor(key_ref, seqlens_k, max_seqlen_k)
+    value_padded = pad_packed_tensor(value_ref, seqlens_k, max_seqlen_k)
+    q_valid, _, atten_mask = make_padded_varlen_mask(
+        seqlens_q,
+        seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        False,
+        *window_size,
+    )
+    fully_masked = atten_mask.all(dim=-1)
+    assert int(fully_masked[1, :seqlens_q[1]].sum()) == 20
+    golden_out_ref, _, golden_out_pt, _ = ref_flash_attention_pair(
+        query_padded,
+        key_padded,
+        value_padded,
+        0.0,
+        atten_mask,
+        torch.bfloat16,
+        softcap,
+    )
+    golden_out_ref[fully_masked] = 0
+    golden_out_pt[fully_masked] = 0
+    assert_fa_close(
+        output_npu,
+        golden_out_ref[q_valid],
+        golden_out_pt[q_valid],
+        softcap=softcap,
+        name="swa_invalid_prefix_out",
+    )


### PR DESCRIPTION
## Related Issue

Fixes #196

## Summary

Fixes Ascend 910 sliding-window attention failures in the V2/V3 varlen paths.

- Keep the logical maximum KV sequence length separate from paged-cache capacity when generating V2 scheduler metadata.
- Clamp invalid prefix/suffix row clearing to the current vector tile, avoiding invalid start/end ranges in the V2 and V3 rescale kernels.
- Add V2/V3 regression coverage for fully masked SWA prefix rows and paged-varlen metadata cases.

## Validation

## Additional Information

None.