### PR TITLE
fix: retain golden cache groups across 910 CI runs

### DIFF
--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -24,6 +24,7 @@
 #   GOLDEN_CACHE_DIR      (默认 /var/cache/flash-attention-npu/golden_cache)
 #   GOLDEN_CACHE_MODE     (默认 cache) cache|off
 #   GOLDEN_CACHE_STATS_FILE (容器内固定为 /tmp/ci_test_logs/golden_cache_events.tsv)
+#   GOLDEN_CACHE_MAX_TEST_DIRS (默认 32, 每个 reference 版本保留的测试文件组数)
 
 set -euo pipefail
 
@@ -142,6 +143,8 @@ run_docker_test() {
       GOLDEN_CACHE_MODE=off
     fi
   fi
+  # Keep all current v2/v3/v4 test-file cache groups.  The old default of 5
+  # caused Ascend910 full runs to evict earlier groups before the next run.
   docker run --rm \
     --label "com.flash-attention-npu.ci.scope=$CI_CONTAINER_SCOPE" \
     "${privileged_args[@]}" \
@@ -166,7 +169,7 @@ run_docker_test() {
     -e GOLDEN_CACHE_STATS_FILE="/tmp/ci_test_logs/golden_cache_events.tsv" \
     -e GOLDEN_CACHE_REFRESH="${GOLDEN_CACHE_REFRESH:-0}" \
     -e GOLDEN_CACHE_MAX_DIRS="${GOLDEN_CACHE_MAX_DIRS:-5}" \
-    -e GOLDEN_CACHE_MAX_TEST_DIRS="${GOLDEN_CACHE_MAX_TEST_DIRS:-5}" \
+    -e GOLDEN_CACHE_MAX_TEST_DIRS="${GOLDEN_CACHE_MAX_TEST_DIRS:-32}" \
     -e FLASH_ATTN_BUILD_VERSION="${FLASH_ATTN_BUILD_VERSION:-all}" \
     -e GIT_CONFIG_GLOBAL=/tmp/gitconfig \
     -w /workspace/flash-attention-npu \

--- a/tests/common/golden_cache.py
+++ b/tests/common/golden_cache.py
@@ -158,8 +158,13 @@ def _limits() -> tuple[int, int]:
         except ValueError:
             return default
 
+    # A full Ascend910 run currently produces cache artifacts for more than
+    # five test files (v2/v3/v4 plus metadata/graph/smoke).  Keeping only five
+    # test directories causes the suite itself to evict artifacts that the
+    # next CI run would otherwise reuse.  Keep a larger, still bounded number
+    # by default; CI can override this with GOLDEN_CACHE_MAX_TEST_DIRS.
     max_common = get("GOLDEN_CACHE_MAX_DIRS", 5)
-    return max_common, get("GOLDEN_CACHE_MAX_TEST_DIRS", max_common)
+    return max_common, get("GOLDEN_CACHE_MAX_TEST_DIRS", 32)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Related Issue

<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->

None.

## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->

The issue of insufficient acceleration effect in testing on the 910 side via golden cache was primarily caused by an overly small limit on the number of cache storage directories. Full-scale testing on the 910 side generates at least nine cache files, while the original default maximum storage count was only five.

## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->