### PR TITLE
Amenderror

### DIFF
--- a/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
+++ b/csrc/ascend910/flash_attn_npu_4/flash_api.cpp
@@ -590,6 +590,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     fwd_args.vDevice = vDevice;
     fwd_args.maskDevice = maskDevice;
     fwd_args.blockTableDevice = blockTableDevice;
+    fwd_args.blockTableStride = paged_KV ? static_cast<uint64_t>(block_table.stride(0)) : 0;
     fwd_args.oDevice = oDevice;
     fwd_args.softmaxLseDevice = softmaxLseDevice;
     fwd_args.qSeqDevice = qSeqDevice;
@@ -677,8 +678,6 @@ at::Tensor get_scheduler_metadata(
     args.numHeadsK = static_cast<uint32_t>(num_heads_kv);
     args.embeddingSize = static_cast<uint32_t>(headdim);
     args.embeddingSizeV = static_cast<uint32_t>(headdim_v);
-    // numBlocks is not consumed by the FAInfer kernel (only blockSize and
-    // maxNumBlocksPerBatch drive the paged addressing); keep it zeroed.
     args.numBlocks = 0;
     args.blockSize = ps;
     args.maxNumBlocksPerBatch = page_size.has_value()

--- a/csrc/ascend910/flash_attn_npu_4/fwd_dispatch.hpp
+++ b/csrc/ascend910/flash_attn_npu_4/fwd_dispatch.hpp
@@ -38,6 +38,7 @@ struct FwdLaunchArgs {
     uint8_t *vDevice;
     uint8_t *maskDevice;          // may be nullptr when is_causal is false
     uint8_t *blockTableDevice;    // may be nullptr when paged_KV is false
+    uint64_t blockTableStride;   // physical row stride, independent of used KV length
     uint8_t *oDevice;
     uint8_t *softmaxLseDevice;
     uint8_t *qSeqDevice;

--- a/csrc/ascend910/flash_attn_npu_4/fwd_dispatch_impl.hpp
+++ b/csrc/ascend910/flash_attn_npu_4/fwd_dispatch_impl.hpp
@@ -27,7 +27,7 @@
         <<<launchBlockDim, nullptr, aclStream>>>(                                  \
             fftsAddr, qDevice, kDevice, vDevice, maskDevice, blockTableDevice,     \
             oDevice, softmaxLseDevice, qSeqDevice, kvSeqDevice,                    \
-            workspaceDevice, tilingDevice)
+            workspaceDevice, tilingDevice, a.blockTableStride)
 
 #define FWD_BOOL_SWITCH(COND, CONST_NAME, ...)             \
     do {                                                   \

--- a/csrc/ascend910/flash_attn_npu_4/kernel_common.hpp
+++ b/csrc/ascend910/flash_attn_npu_4/kernel_common.hpp
@@ -73,14 +73,16 @@ namespace KernelCommon {
         GM_ADDR lse;
         GM_ADDR workSpace;
         GM_ADDR tiling;
+        uint64_t blockTableStride;
 
         __aicore__ inline FAIKernelParams() {}
 
         __aicore__ inline FAIKernelParams(GM_ADDR q_, GM_ADDR k_, GM_ADDR v_, GM_ADDR mask_, GM_ADDR blockTables_,
                 GM_ADDR actualQseqlen_, GM_ADDR actualKvseqlen_, GM_ADDR o_, GM_ADDR lse_, GM_ADDR workSpace_,
-                    GM_ADDR tiling_)
+                    GM_ADDR tiling_, uint64_t blockTableStride_)
             : q(q_), k(k_), v(v_), mask(mask_), blockTables(blockTables_), actualQseqlen(actualQseqlen_),
-                actualKvseqlen(actualKvseqlen_), o(o_), lse(lse_), workSpace(workSpace_), tiling(tiling_) {}
+                actualKvseqlen(actualKvseqlen_), o(o_), lse(lse_), workSpace(workSpace_), tiling(tiling_),
+                blockTableStride(blockTableStride_) {}
     };
 
     __aicore__ inline uint32_t GetQNBlockTile(uint32_t qSeqlen, uint32_t groupSize)

--- a/csrc/ascend910/flash_attn_npu_4/mha_fwd_kvcache.cpp
+++ b/csrc/ascend910/flash_attn_npu_4/mha_fwd_kvcache.cpp
@@ -111,7 +111,9 @@ namespace SplitFuse {
             embed = fATilingData->embeddingSize;
             embedV = fATilingData->embeddingSizeV;
             pagedBlockSize = fATilingData->blockSize;
-            maxNumBlocksPerBatch = fATilingData->maxNumBlocksPerBatch;
+            // Metadata may infer capacity from the used KV length. The page
+            // table can reserve more pages or be a view with a larger stride.
+            blockTableStride = params.blockTableStride;
             firstBatchTaskNum = fATilingData->firstBatchTaskNum;
             totalTaskNum = fATilingData->totalTaskNum;
             blockSize = fATilingData->blockSize;
@@ -500,7 +502,7 @@ namespace SplitFuse {
                 kBOffset = static_cast<uint64_t>(prevKvSeqlenSum) * strideK;
                 vBOffset = static_cast<uint64_t>(prevKvSeqlenSum) * strideV;
             } else {
-                blockBOffset = static_cast<uint64_t>(BIdx) * static_cast<uint64_t>(maxNumBlocksPerBatch);
+                blockBOffset = static_cast<uint64_t>(BIdx) * blockTableStride;
             }
             uint64_t oBOffset = static_cast<uint64_t>(prevQSeqlenSum) * strideO;
             // LSE flat offset depends on the output layout the host allocates:
@@ -997,7 +999,7 @@ namespace SplitFuse {
         uint32_t embed;
         uint32_t embedV;
         uint32_t pagedBlockSize;
-        uint32_t maxNumBlocksPerBatch;
+        uint64_t blockTableStride;
         uint32_t firstBatchTaskNum;
         uint32_t totalTaskNum;
         uint32_t blockSize;
@@ -1051,7 +1053,8 @@ namespace SplitFuse {
         GM_ADDR actualQseqlen,
         GM_ADDR actualKvseqlen,
         GM_ADDR workspace,
-        GM_ADDR tiling)
+        GM_ADDR tiling,
+        uint64_t blockTableStride)
     {
         AscendC::SetSyncBaseAddr(fftsAddr);
 
@@ -1114,7 +1117,8 @@ namespace SplitFuse {
             FAInferKernel<BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO,
                           PagedCacheFlag, maskCategory, inLayout, CombineScale>;
 
-        FAIKernelParams params{q, k, v, mask, blockTables, actualQseqlen, actualKvseqlen, o, lse, workspace, tiling};
+        FAIKernelParams params{q, k, v, mask, blockTables, actualQseqlen, actualKvseqlen, o, lse, workspace, tiling,
+                              blockTableStride};
         FAInferKernelType flashAttnInfer;
         flashAttnInfer(params);
     }

--- a/csrc/ascend910/flash_attn_npu_4/online_softmax.hpp
+++ b/csrc/ascend910/flash_attn_npu_4/online_softmax.hpp
@@ -648,16 +648,37 @@ public:
             AscendC::PipeBarrier<PIPE_V>();
         } else {
             SetVecMask(rowNumCurLoop);
-            // *** hm = vmax(lm, gm)
-            AscendC::Max<float, false>(
-                hmUbTensor[rowOffset],
-                lmUbTensor[rowOffset],
-                gmUbTensor[rowOffset],
-                (uint64_t)0,
-                1,
-                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            // Compute hm directly before the correction gm - hm. Reconstructing
+            // hm from gm - min(0, gm - max(lm, gm) + threshold) loses the finite
+            // maximum when gm=-3e38 after a fully masked tile. That can overflow
+            // the FP16 probabilities when the next tile has valid keys.
+            if (rescaleThreshold > 0.0f) {
+                // hm = max(gm, lm - threshold).
+                AscendC::Adds<float, false>(
+                    hmUbTensor[rowOffset],
+                    lmUbTensor[rowOffset],
+                    -rescaleThreshold,
+                    (uint64_t)0,
+                    1,
+                    AscendC::UnaryRepeatParams(1, 1, 8, 8));
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Max<float, false>(
+                    hmUbTensor[rowOffset],
+                    hmUbTensor[rowOffset],
+                    gmUbTensor[rowOffset],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            } else {
+                AscendC::Max<float, false>(
+                    hmUbTensor[rowOffset],
+                    lmUbTensor[rowOffset],
+                    gmUbTensor[rowOffset],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            }
             AscendC::PipeBarrier<PIPE_V>();
-            // *** dm = gm - hm  (= -delta, delta = hm - gm >= 0)
             AscendC::Sub<float, false>(
                 dmUbTensor[dmUbOffsetCurCycle],
                 gmUbTensor[rowOffset],
@@ -666,40 +687,6 @@ public:
                 1,
                 AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
             AscendC::PipeBarrier<PIPE_V>();
-            // *** FA4 逐行阈值跳过:当某行 delta <= rescaleThreshold 时保持旧基准 hm=gm,
-            //     使 correction dm=exp(0)=1,从而跳过对 gl/O 的 rescale。闭式等价于
-            //     hm = max(gm, lm - rescaleThreshold),对每行独立成立、数学结果精确;
-            //     当前 tile 内 exp 值上界为 e^rescaleThreshold。rescaleThreshold<=0 时整段
-            //     被跳过,退回逐块更新的原始行为
-            if (rescaleThreshold > 0.0f) {
-                // dm = threshold - delta
-                AscendC::Adds<float, false>(
-                    dmUbTensor[dmUbOffsetCurCycle],
-                    dmUbTensor[dmUbOffsetCurCycle],
-                    rescaleThreshold,
-                    (uint64_t)0,
-                    1,
-                    AscendC::UnaryRepeatParams(1, 1, 8, 8));
-                AscendC::PipeBarrier<PIPE_V>();
-                // dm = min(0, threshold - delta) = -relu(delta - threshold)
-                AscendC::Mins<float, false>(
-                    dmUbTensor[dmUbOffsetCurCycle],
-                    dmUbTensor[dmUbOffsetCurCycle],
-                    0.0f,
-                    (uint64_t)0,
-                    1,
-                    AscendC::UnaryRepeatParams(1, 1, 8, 8));
-                AscendC::PipeBarrier<PIPE_V>();
-                // hm = gm - dm = gm + relu(delta - threshold) = max(gm, lm - threshold)
-                AscendC::Sub<float, false>(
-                    hmUbTensor[rowOffset],
-                    gmUbTensor[rowOffset],
-                    dmUbTensor[dmUbOffsetCurCycle],
-                    (uint64_t)0,
-                    1,
-                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
-                AscendC::PipeBarrier<PIPE_V>();
-            }
             // *** dm = exp(dm)
             AscendC::Exp<float, false>(
                 dmUbTensor[dmUbOffsetCurCycle],

--- a/tests/test_flash_attn_npu_v4.py
+++ b/tests/test_flash_attn_npu_v4.py
@@ -215,16 +215,12 @@ test_cases = [
     (torch.float16, 2, 6, 3, 3, 799, 59, 1, 128, False, "TND", True, 460, 62, 1),
     (torch.float16, 2, 6, 1, 1, 128, 80, 1, 128, False, "TND", True, -1, -1, 1),
     (torch.float16, 2, 6, 3, 3, 1024, 32, 1, 128, False, "TND", True, 0, 256, 1),
-    # Known unresolved issue: kv=20000 + window=(0,256) + paged TND triggers
-    # kernel NaNs (formerly data_type101/103). Trigger: non-causal,
-    # window_left=0, and long KV (kv around 19980). Middle output rows become
-    # NaN while LSE remains valid. Temporarily disabled pending kernel analysis.
-    # (torch.float16, 2, 6, 6, 16, 20000, 59, 1, 128, False, "TND", True, 0, 256, 1),
+    (torch.float16, 2, 6, 6, 16, 20000, 59, 1, 128, False, "TND", True, 0, 256, 1),
 
 # data_type=float16, is_causal=True, cache_mode=1, layout=TND, is_varied=True, num_splits=1
 #   num_heads,kv_heads in {(6,6),(6,1),(6,3)}, head_size=A, (q_seqlen,kv_seqlen)=seqA, (window_left,window_right)=winA
     (torch.float16, 2, 6, 1, 1, 128, 32, 1, 128, True, "TND", True, 460, 62, 1),
-    # (torch.float16, 2, 6, 6, 16, 20000, 59, 1, 128, True, "TND", True, 0, 256, 1),
+    (torch.float16, 2, 6, 6, 16, 20000, 59, 1, 128, True, "TND", True, 0, 256, 1),
     (torch.float16, 2, 6, 6, 16, 131072, 32, 1, 128, True, "TND", True, 59, 571, 1),
     (torch.float16, 2, 6, 3, 3, 799, 80, 1, 128, True, "TND", True, -1, -1, 1),
     (torch.float16, 2, 6, 3, 3, 1024, 64, 1, 128, True, "TND", True, -1, -1, 1),

--- a/tests/test_flash_attn_npu_v4.py
+++ b/tests/test_flash_attn_npu_v4.py
@@ -298,6 +298,11 @@ test_cases = [
     (torch.float16, 1, 10, 2, 3, 4096, 192, 1, 128, False, "TND", False, -1, -1, 3),
     # Non-16-aligned head dim exercises packed Partial O DMA.
     (torch.float16, 1, 6, 1, 3, 4096, 59, 1, 128, False, "TND", False, -1, -1, 4),
+    # Reported paged-TND regressions: split-KV with large/unaligned D and
+    # causal variable lengths. Keep these in the common suite, including 910.
+    (torch.bfloat16, 2, 16, 4, 129, 513, 201, 1, 128, False, "TND", True, -1, -1, 2),
+    (torch.float16, 2, 24, 2, 129, 513, 224, 1, 128, False, "TND", True, -1, -1, 2),
+    (torch.bfloat16, 5, 24, 4, 128, 129, 63, 1, 128, True, "TND", True, -1, -1, 1),
     # Maximum merged-M tile: q_seqlen=16 * 8 Q heads = 128 rows.
     (torch.bfloat16, 1, 8, 1, 16, 4096, 64, 1, 128, False, "TND", False, -1, -1, 4),
     # Auto-split FD with Q-head merging and causal masking.

--- a/tests/test_flash_attn_npu_v4_metadata.py
+++ b/tests/test_flash_attn_npu_v4_metadata.py
@@ -20,6 +20,7 @@ from tests.common.test_utils import gather_paged_kv_batch, make_random_tensor
 
 WINDOW_SIZE = (-1, -1)
 
+
 def _prefix_sums(lengths):
     offsets = [0]
     for length in lengths:


### PR DESCRIPTION
## Related Issue


<!--
Use the appropriate keyword for each related issue:
  1) If this PR completely resolves an issue, you can use:
    Fixes #123, or
    Closes #123, or
    Resolves #123

  2) If this PR is related to an issue but should NOT close it, you can use:
    Related to #123, or
    Refs #123

Otherwise, if there is no related issue, write:
    None.
-->
Resolves #216 



## Summary

<!--
Briefly describe what this PR does and highlight the main changes.

Example:

Adds support for xxx feature in flash-attention-npu.

- Implemented xxx feature computation in the xxx kernel.
- Extended xxx API to support the xxx feature.
- Added or updated xxx unit tests for the xxx feature.
-->
存在两个问题：


1. softmax 阶段数值溢出的问题：
  原来的 Ascend C 调用顺序：
  Max → Sub → Adds → Mins → Sub → Exp
  旧代码的主要计算顺序是：

  hm = max(lm, gm);
  dm = gm - hm;

  if (rescaleThreshold > 0) {
      dm = dm + rescaleThreshold;
      dm = min(dm, 0);
      hm = gm - dm;
  }
  当阈值大于 0 时，这段代码在实数数学上等价于：
  hm = max(gm, lm - rescaleThreshold);
  dm = exp(gm - hm)

  旧代码在 FP32 下会经历：

  hm = max(20, -3e38);      // 20

  dm = -3e38 - 20;          // 舍入后仍约为 -3e38
  dm = dm + 4;             // 舍入后仍约为 -3e38
  dm = min(dm, 0);          // 仍约为 -3e38

  hm = -3e38 - (-3e38);     // 得到 0

  FP32 在 3e38 这个量级已经无法保留 20、4 这么小的差值。最后两个相同的大数相减，得到 0。

  但正确的新基准应该是：

  hm = max(-3e38, 20 - 4);  // 16
但是 后面的 CalcExp() 会使用这个 hm：
P = exp(score - hm);
导致数值溢出。



2. blocktable stride 取值错误问题
golden 在构造的时候， 输入的case 是kvseqlen = 513, 两个batch 构造的blocktable页表长度是5， 但是kvseqlen的时候使用0~513 随机取值取到的470， kennel 实际的取值也是470, 计算实际得到的blocktable  stride 是4, 导致第二个batch 取值的时候取到的脏数据，导致精度错误。


## Validation

<!--
Provide evidence that your changes have been tested or validated.

Examples include:
- Screenshots.
- Test results.
- Benchmark results.
- Console logs.
-->



## Additional Information

<!--
Optional.

Include any additional context that may help reviewers, such as
known limitations, follow-up work, or other relevant notes.

If not applicable, write:
None.
-->